### PR TITLE
Fix setup.py to allow successful wheel builds for PyPI releases

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ class VerifyVersionCommand(install):
             )
 
 
-install_requires = open('requirements.txt').read().strip().split('\n')
+install_requires = ["wheel", "pythonnet==2.5.2", "pydantic>=1.9.0", "loguru>=0.6.0", "pillow>=9.1.0", "versioneer"]
 
 cmdclass = {
     "verify_version": VerifyVersionCommand,


### PR DESCRIPTION
Fixes #11 Fix setup.py to allow successful wheel builds for PyPI releases

![image](https://user-images.githubusercontent.com/40097932/169645188-e4e4fc76-5ac7-4642-987e-abea5f2709ed.png)
