### PR TITLE
ubuntuFix OS to Ubuntu on publish config

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "autoDocstring.docstringFormat": "sphinx-notypes",
     "cSpell.words": [
         "flaui",
+        "pydantic",
         "uiautomation",
         "versioneer"
     ],


### PR DESCRIPTION
Fixes #16 Fix OS to Ubuntu on publish config to allow builds to run on GitHub Actions