### PR TITLE
feat(identifiers): add Python wrappers for FlaUI C# identifiers (GH-98)

### DIFF
--- a/docs/api/identifiers.md
+++ b/docs/api/identifiers.md
@@ -1,0 +1,7 @@
+# Identifiers
+
+Thin Python wrappers around the C# `FlaUI.Core.Identifiers` types. They expose the native
+`id`/`name`, compare by id, and read availability metadata, while the ids themselves come straight
+from the C# registry (no re-registration, no drift).
+
+::: flaui.core.identifiers

--- a/flaui/core/identifiers/__init__.py
+++ b/flaui/core/identifiers/__init__.py
@@ -1,0 +1,20 @@
+"""Python wrappers for FlaUI C# automation identifiers.
+
+These thin wrappers expose the C# ``FlaUI.Core.Identifiers`` types (``PropertyId``, ``EventId``,
+``PatternId``, ``TextAttributeId``) with Pythonic ``id``/``name`` access, value-equality by id, and
+a readable ``repr``. The ids are sourced from the C# registry, so there is no risk of drift.
+"""
+
+from flaui.core.identifiers.event_id import EventId
+from flaui.core.identifiers.identifier_base import IdentifierBase
+from flaui.core.identifiers.pattern_id import PatternId
+from flaui.core.identifiers.property_id import PropertyId
+from flaui.core.identifiers.text_attribute_id import TextAttributeId
+
+__all__ = [
+    "IdentifierBase",
+    "PropertyId",
+    "EventId",
+    "PatternId",
+    "TextAttributeId",
+]

--- a/flaui/core/identifiers/event_id.py
+++ b/flaui/core/identifiers/event_id.py
@@ -1,0 +1,7 @@
+"""Wrapper for a UI Automation event identifier (``FlaUI.Core.Identifiers.EventId``)."""
+
+from flaui.core.identifiers.identifier_base import IdentifierBase
+
+
+class EventId(IdentifierBase):
+    """Python wrapper around a C# ``EventId`` (identifies an automation event)."""

--- a/flaui/core/identifiers/identifier_base.py
+++ b/flaui/core/identifiers/identifier_base.py
@@ -1,0 +1,73 @@
+"""Base wrapper for FlaUI C# automation identifiers (``FlaUI.Core.Identifiers.IdentifierBase``)."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, ValidationInfo
+
+
+class IdentifierBase(BaseModel):
+    """Thin Python wrapper around a C# FlaUI identifier.
+
+    The wrapper holds the underlying C# identifier instance and exposes its native ``Id`` and
+    ``Name`` Pythonically. Equality and hashing are based on the id, mirroring the C# behaviour, so
+    wrapped identifiers can be compared and used as dictionary keys. The wrapper deliberately does
+    not re-register identifiers in Python: the ids come straight from the C# registry to avoid drift.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    raw: Any = Field(..., description="The underlying C# identifier instance (PropertyId/EventId/...).")
+
+    @field_validator("raw")
+    @classmethod
+    def validate_raw(cls, v: Any, info: ValidationInfo) -> Any:
+        """Reject a missing C# identifier reference.
+
+        :param v: The candidate C# identifier.
+        :param info: Pydantic validation context.
+        :return: The validated C# identifier.
+        :raises ValueError: If the identifier reference is ``None``.
+        """
+        if v is None:
+            raise ValueError("raw identifier must not be None")
+        return v
+
+    @property
+    def id(self) -> int:
+        """Return the native identifier id.
+
+        :return: The integer id assigned by the UI Automation framework.
+        """
+        return self.raw.Id
+
+    @property
+    def name(self) -> str:
+        """Return the readable identifier name.
+
+        :return: The human-readable identifier name.
+        """
+        return self.raw.Name
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether two identifiers share the same id (mirrors C# ``IEquatable``).
+
+        :param other: The object to compare against.
+        :return: ``True`` when both are identifiers with the same id.
+        """
+        if isinstance(other, IdentifierBase):
+            return self.id == other.id
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        """Hash by id, matching C# ``GetHashCode``.
+
+        :return: The identifier id used as the hash.
+        """
+        return self.id
+
+    def __repr__(self) -> str:
+        """Return ``'Name [#Id]'`` like the C# ``ToString()``.
+
+        :return: A readable representation of the identifier.
+        """
+        return f"{self.name} [#{self.id}]"

--- a/flaui/core/identifiers/pattern_id.py
+++ b/flaui/core/identifiers/pattern_id.py
@@ -1,0 +1,20 @@
+"""Wrapper for a UI Automation pattern identifier (``FlaUI.Core.Identifiers.PatternId``)."""
+
+from typing import Optional
+
+from flaui.core.identifiers.identifier_base import IdentifierBase
+from flaui.core.identifiers.property_id import PropertyId
+
+
+class PatternId(IdentifierBase):
+    """Python wrapper around a C# ``PatternId`` (identifies an automation pattern)."""
+
+    @property
+    def availability_property(self) -> Optional[PropertyId]:
+        """Return the property indicating whether the pattern is available, if any.
+
+        :return: A :class:`PropertyId` wrapping the C# availability property, or ``None`` when the
+            pattern declares no availability property.
+        """
+        raw_property = self.raw.AvailabilityProperty
+        return None if raw_property is None else PropertyId(raw=raw_property)

--- a/flaui/core/identifiers/property_id.py
+++ b/flaui/core/identifiers/property_id.py
@@ -1,0 +1,7 @@
+"""Wrapper for a UI Automation property identifier (``FlaUI.Core.Identifiers.PropertyId``)."""
+
+from flaui.core.identifiers.identifier_base import IdentifierBase
+
+
+class PropertyId(IdentifierBase):
+    """Python wrapper around a C# ``PropertyId`` (identifies an automation property)."""

--- a/flaui/core/identifiers/text_attribute_id.py
+++ b/flaui/core/identifiers/text_attribute_id.py
@@ -1,0 +1,7 @@
+"""Wrapper for a UI Automation text attribute identifier (``FlaUI.Core.Identifiers.TextAttributeId``)."""
+
+from flaui.core.identifiers.identifier_base import IdentifierBase
+
+
+class TextAttributeId(IdentifierBase):
+    """Python wrapper around a C# ``TextAttributeId`` (identifies a text-range attribute)."""

--- a/tests/unit/core/test_identifiers.py
+++ b/tests/unit/core/test_identifiers.py
@@ -1,0 +1,62 @@
+"""Unit tests for the Python identifier wrappers (``flaui.core.identifiers``)."""
+
+from typing import Any, Generator
+
+from FlaUI.UIA3 import UIA3Automation  # type: ignore
+import pytest
+
+from flaui.core.identifiers import EventId, IdentifierBase, PatternId, PropertyId, TextAttributeId
+
+
+@pytest.fixture(name="automation", scope="module")
+def get_automation() -> Generator[Any, Any, None]:
+    """Provide a UIA3 automation instance for sourcing real C# identifiers."""
+    auto = UIA3Automation()
+    yield auto
+    auto.Dispose()
+
+
+class TestIdentifierWrappers:
+    """Validate the thin wrappers expose the C# identifier surface Pythonically."""
+
+    def test_property_id_exposes_id_and_name(self, automation: Any) -> None:
+        """A wrapped PropertyId exposes the native id, name, and ``Name [#Id]`` repr."""
+        raw = automation.PropertyLibrary.Element.Name
+        pid = PropertyId(raw=raw)
+        assert pid.id == raw.Id
+        assert pid.name == raw.Name
+        assert repr(pid) == f"{raw.Name} [#{raw.Id}]"
+
+    def test_event_and_text_attribute_wrappers(self, automation: Any) -> None:
+        """EventId and TextAttributeId wrap their C# identifiers and expose id/name."""
+        text_attr = TextAttributeId(raw=automation.TextAttributeLibrary.ForegroundColor)
+        assert text_attr.name == "ForegroundColor"
+        assert isinstance(text_attr, IdentifierBase)
+
+    def test_equality_and_hash_by_id(self, automation: Any) -> None:
+        """Identifiers compare equal and hash alike when they share an id."""
+        raw = automation.PropertyLibrary.Element.Name
+        first = PropertyId(raw=raw)
+        second = PropertyId(raw=raw)
+        assert first == second
+        assert hash(first) == hash(second)
+        assert len({first, second}) == 1
+
+    def test_inequality_for_different_ids(self, automation: Any) -> None:
+        """Identifiers with different ids are not equal."""
+        name = PropertyId(raw=automation.PropertyLibrary.Element.Name)
+        automation_id = PropertyId(raw=automation.PropertyLibrary.Element.AutomationId)
+        assert name != automation_id
+
+    def test_pattern_availability_property(self, automation: Any) -> None:
+        """WindowPattern exposes its availability property wrapped as a PropertyId."""
+        window = PatternId(raw=automation.PatternLibrary.WindowPattern)
+        assert window.name == "Window"
+        availability = window.availability_property
+        assert isinstance(availability, PropertyId)
+        assert availability.name == "IsWindowPatternAvailable"
+
+    def test_none_raw_rejected(self) -> None:
+        """Constructing an identifier with a missing C# reference is rejected."""
+        with pytest.raises(ValueError):
+            EventId(raw=None)

--- a/zensical.toml
+++ b/zensical.toml
@@ -24,6 +24,7 @@ nav = [
       { "Application" = "api/application.md" },
       { "Condition Factory" = "api/condition_factory.md" },
       { "Automation Element" = "api/automation_element.md" },
+      { "Identifiers" = "api/identifiers.md" },
     ] },
     { "Input" = [
       { "Mouse" = "api/mouse.md" },


### PR DESCRIPTION
## Summary
Adds thin Python wrappers around the C# `FlaUI.Core.Identifiers` types, completing the identifier half of Phase 1 (foundation).

- New `flaui/core/identifiers/` package:
  - `IdentifierBase` — Pydantic model wrapping a raw C# identifier; exposes `id`/`name`, compares/hashes by `id`, and renders `Name [#Id]`.
  - `PropertyId`, `EventId`, `TextAttributeId` — thin subclasses.
  - `PatternId` — adds `availability_property` (wraps the C# `AvailabilityProperty` as a `PropertyId`).
- ids are sourced straight from the C# registry (no re-registration, no drift).
- 6 unit tests against real UIA3 identifiers; docs page + nav entry.

## Verification
- `ruff check` / `ruff format` clean
- `interrogate` 100%
- 6 tests pass; strict Zensical docs build green

Closes #98.