### PR TITLE
feat(patterns): pattern-access architecture + first pattern family (GH-91)

### DIFF
--- a/docs/api/patterns.md
+++ b/docs/api/patterns.md
@@ -1,0 +1,18 @@
+# Patterns
+
+Python wrappers around the C# `FlaUI.Core.Patterns` types. The `Patterns` facade (exposed as
+`element.patterns`) gives typed, snake_case access to each UI Automation pattern, mirroring the C#
+`element.Patterns.<Pattern>.Pattern` shape one-to-one:
+
+```python
+# C#:  element.Patterns.Value.Pattern.Value.Value
+element.patterns.value.pattern.value.value
+
+# C#:  element.Patterns.Toggle.IsSupported
+element.patterns.toggle.is_supported
+```
+
+Each pattern wraps a native C# pattern object, always reachable via `raw_pattern` as an escape
+hatch for members that are not yet wrapped. Patterns are ported incrementally by family.
+
+::: flaui.core.patterns

--- a/flaui/core/automation_elements.py
+++ b/flaui/core/automation_elements.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import abc
 from datetime import date
 import logging
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, TypeVar, Union, overload
 
 import arrow
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
@@ -40,6 +40,9 @@ from flaui.lib.system.drawing import (
     Rectangle,
     Size,
 )
+
+if TYPE_CHECKING:
+    from flaui.core.patterns import Patterns
 
 # ================================================================================
 #   Element base Pydantic abstract class
@@ -241,12 +244,18 @@ class ElementBase(ElementModel, abc.ABC):  # pragma: no cover
 
     @property
     @handle_csharp_exceptions
-    def patterns(self) -> Any:
-        """Standard UIA patterns of this element
+    def patterns(self) -> "Patterns":
+        """Standard UIA patterns of this element.
 
-        :return: UIA Patterns
+        Mirrors C# ``element.Patterns``: each accessor returns a typed pattern accessor, e.g.
+        ``element.patterns.value.pattern.value.value``. The underlying C# object remains reachable
+        via ``element.patterns.raw_patterns``.
+
+        :return: UIA Patterns facade
         """
-        return self.raw_element.Patterns
+        from flaui.core.patterns import Patterns
+
+        return Patterns(raw_patterns=self.raw_element.Patterns)
 
     @property
     @handle_csharp_exceptions

--- a/flaui/core/patterns/__init__.py
+++ b/flaui/core/patterns/__init__.py
@@ -1,0 +1,31 @@
+"""Python wrappers for FlaUI C# UI Automation patterns.
+
+This package mirrors ``FlaUI.Core.Patterns``. The :class:`~flaui.core.patterns.patterns.Patterns`
+facade (exposed as ``element.patterns``) gives typed, snake_case access to each pattern, matching
+the C# ``element.Patterns.<Pattern>.Pattern`` shape. Each pattern wraps a native C# pattern object
+reachable via :attr:`~flaui.core.patterns.pattern_base.PatternBase.raw_pattern`.
+
+Patterns are ported incrementally by family; this module re-exports the ones available so far.
+"""
+
+from flaui.core.patterns.automation_pattern import AutomationPattern
+from flaui.core.patterns.expand_collapse_pattern import ExpandCollapsePattern
+from flaui.core.patterns.grid_pattern import GridPattern
+from flaui.core.patterns.invoke_pattern import InvokePattern
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.core.patterns.patterns import Patterns
+from flaui.core.patterns.range_value_pattern import RangeValuePattern
+from flaui.core.patterns.toggle_pattern import TogglePattern
+from flaui.core.patterns.value_pattern import ValuePattern
+
+__all__ = [
+    "AutomationPattern",
+    "ExpandCollapsePattern",
+    "GridPattern",
+    "InvokePattern",
+    "PatternBase",
+    "Patterns",
+    "RangeValuePattern",
+    "TogglePattern",
+    "ValuePattern",
+]

--- a/flaui/core/patterns/automation_pattern.py
+++ b/flaui/core/patterns/automation_pattern.py
@@ -1,0 +1,58 @@
+"""Wrapper for the C# ``IAutomationPattern<T>`` pattern accessor.
+
+Mirrors ``FlaUI.Core.IAutomationPattern<T>``: it lazily materialises a pattern on an element and
+reports whether the element supports it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Generic, Optional, Tuple, Type, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from flaui.core.patterns.pattern_base import PatternBase
+
+TPattern = TypeVar("TPattern", bound=PatternBase)
+
+
+class AutomationPattern(BaseModel, Generic[TPattern]):
+    """Provides access to a single pattern on an element, mirroring C# ``IAutomationPattern<T>``."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    raw_automation_pattern: Any = Field(..., description="The underlying C# IAutomationPattern<T> object")
+    pattern_type: Type[TPattern] = Field(..., description="Python wrapper class used to wrap the native pattern")
+
+    @property
+    def is_supported(self) -> bool:
+        """Return whether the element supports this pattern.
+
+        :return: ``True`` if the pattern is supported, else ``False``.
+        """
+        return self.raw_automation_pattern.IsSupported
+
+    @property
+    def pattern(self) -> TPattern:
+        """Return the wrapped pattern, raising if the pattern is not supported.
+
+        :return: The wrapped pattern instance.
+        :raises PatternNotSupportedException: If the element does not support the pattern.
+        """
+        return self.pattern_type(raw_pattern=self.raw_automation_pattern.Pattern)
+
+    @property
+    def pattern_or_default(self) -> Optional[TPattern]:
+        """Return the wrapped pattern, or ``None`` if the pattern is not supported.
+
+        :return: The wrapped pattern instance, or ``None`` when unsupported.
+        """
+        raw = self.raw_automation_pattern.PatternOrDefault
+        return None if raw is None else self.pattern_type(raw_pattern=raw)
+
+    def try_get_pattern(self) -> Tuple[bool, Optional[TPattern]]:
+        """Try to get the wrapped pattern.
+
+        :return: A tuple ``(supported, pattern_or_none)``.
+        """
+        pattern = self.pattern_or_default
+        return pattern is not None, pattern

--- a/flaui/core/patterns/expand_collapse_pattern.py
+++ b/flaui/core/patterns/expand_collapse_pattern.py
@@ -1,0 +1,30 @@
+"""Wrapper for the UI Automation ExpandCollapse pattern (``IExpandCollapsePattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class ExpandCollapsePattern(PatternBase):
+    """Represents the UI Automation ExpandCollapse pattern for controls that expand and collapse."""
+
+    @property
+    @handle_csharp_exceptions
+    def expand_collapse_state(self) -> AutomationProperty:
+        """Return the current expand/collapse state.
+
+        :return: An :class:`AutomationProperty` wrapping the ``ExpandCollapseState`` value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.ExpandCollapseState)
+
+    @handle_csharp_exceptions
+    def expand(self) -> None:
+        """Expand the control."""
+        self.raw_pattern.Expand()
+
+    @handle_csharp_exceptions
+    def collapse(self) -> None:
+        """Collapse the control."""
+        self.raw_pattern.Collapse()

--- a/flaui/core/patterns/grid_pattern.py
+++ b/flaui/core/patterns/grid_pattern.py
@@ -1,0 +1,39 @@
+"""Wrapper for the UI Automation Grid pattern (``IGridPattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationElement, AutomationProperty
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class GridPattern(PatternBase):
+    """Represents the UI Automation Grid pattern for controls arranged in a grid of cells."""
+
+    @property
+    @handle_csharp_exceptions
+    def column_count(self) -> AutomationProperty:
+        """Return the number of columns in the grid.
+
+        :return: An :class:`AutomationProperty` wrapping the column count.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.ColumnCount)
+
+    @property
+    @handle_csharp_exceptions
+    def row_count(self) -> AutomationProperty:
+        """Return the number of rows in the grid.
+
+        :return: An :class:`AutomationProperty` wrapping the row count.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.RowCount)
+
+    @handle_csharp_exceptions
+    def get_item(self, row: int, column: int) -> AutomationElement:
+        """Return the cell at the given zero-based row and column.
+
+        :param row: Zero-based row index.
+        :param column: Zero-based column index.
+        :return: The :class:`AutomationElement` at the requested cell.
+        """
+        return AutomationElement(raw_element=self.raw_pattern.GetItem(row, column))

--- a/flaui/core/patterns/invoke_pattern.py
+++ b/flaui/core/patterns/invoke_pattern.py
@@ -1,0 +1,15 @@
+"""Wrapper for the UI Automation Invoke pattern (``IInvokePattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class InvokePattern(PatternBase):
+    """Represents the UI Automation Invoke pattern for controls that perform a single action."""
+
+    @handle_csharp_exceptions
+    def invoke(self) -> None:
+        """Invoke the control (perform its primary action)."""
+        self.raw_pattern.Invoke()

--- a/flaui/core/patterns/pattern_base.py
+++ b/flaui/core/patterns/pattern_base.py
@@ -1,0 +1,37 @@
+"""Base Pydantic model for FlaUI UI Automation pattern wrappers.
+
+Mirrors the C# ``FlaUI.Core.Patterns.Infrastructure.PatternBase`` shape: every pattern wraps a
+native C# pattern object and exposes its properties (as :class:`~flaui.core.automation_elements.AutomationProperty`)
+and methods. The wrapped C# object is always reachable via :attr:`PatternBase.raw_pattern` as an
+escape hatch for members that are not yet ported.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+from flaui.lib.exceptions import PatternNotSupportedException
+
+
+class PatternBase(BaseModel, abc.ABC):  # pragma: no cover
+    """Base model wrapping a native C# FlaUI pattern object."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    raw_pattern: Any = Field(..., description="The underlying C# FlaUI pattern object")
+
+    @field_validator("raw_pattern")
+    def validate_pattern_exists(cls, v: Any, info: ValidationInfo) -> Any:
+        """Validate the native pattern object exists.
+
+        :param v: Raw C# pattern object.
+        :param info: Pydantic validation info.
+        :raises PatternNotSupportedException: If the pattern object is ``None``.
+        :return: The validated raw pattern object.
+        """
+        if v is None:
+            raise PatternNotSupportedException("Pattern is not supported by this element")
+        return v

--- a/flaui/core/patterns/patterns.py
+++ b/flaui/core/patterns/patterns.py
@@ -1,0 +1,92 @@
+"""Facade over a FlaUI element's patterns, mirroring C# ``IFrameworkPatterns``.
+
+This is the Python equivalent of ``element.Patterns`` in C#. Each accessor returns an
+:class:`~flaui.core.patterns.automation_pattern.AutomationPattern`, so usage mirrors the C# API
+one-to-one::
+
+    element.patterns.value.pattern.value.value      # C#: element.Patterns.Value.Pattern.Value.Value
+    element.patterns.toggle.is_supported             # C#: element.Patterns.Toggle.IsSupported
+
+The underlying C# ``IFrameworkPatterns`` object remains reachable via :attr:`Patterns.raw_patterns`
+as an escape hatch for patterns that are not yet wrapped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from flaui.core.patterns.automation_pattern import AutomationPattern
+from flaui.core.patterns.expand_collapse_pattern import ExpandCollapsePattern
+from flaui.core.patterns.grid_pattern import GridPattern
+from flaui.core.patterns.invoke_pattern import InvokePattern
+from flaui.core.patterns.range_value_pattern import RangeValuePattern
+from flaui.core.patterns.toggle_pattern import TogglePattern
+from flaui.core.patterns.value_pattern import ValuePattern
+
+
+class Patterns(BaseModel):
+    """Provides typed access to the UI Automation patterns of an element."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    raw_patterns: Any = Field(..., description="The underlying C# IFrameworkPatterns object")
+
+    @property
+    def invoke(self) -> AutomationPattern[InvokePattern]:
+        """Access the Invoke pattern.
+
+        :return: The Invoke pattern accessor.
+        """
+        return AutomationPattern[InvokePattern](
+            raw_automation_pattern=self.raw_patterns.Invoke, pattern_type=InvokePattern
+        )
+
+    @property
+    def toggle(self) -> AutomationPattern[TogglePattern]:
+        """Access the Toggle pattern.
+
+        :return: The Toggle pattern accessor.
+        """
+        return AutomationPattern[TogglePattern](
+            raw_automation_pattern=self.raw_patterns.Toggle, pattern_type=TogglePattern
+        )
+
+    @property
+    def value(self) -> AutomationPattern[ValuePattern]:
+        """Access the Value pattern.
+
+        :return: The Value pattern accessor.
+        """
+        return AutomationPattern[ValuePattern](
+            raw_automation_pattern=self.raw_patterns.Value, pattern_type=ValuePattern
+        )
+
+    @property
+    def range_value(self) -> AutomationPattern[RangeValuePattern]:
+        """Access the RangeValue pattern.
+
+        :return: The RangeValue pattern accessor.
+        """
+        return AutomationPattern[RangeValuePattern](
+            raw_automation_pattern=self.raw_patterns.RangeValue, pattern_type=RangeValuePattern
+        )
+
+    @property
+    def expand_collapse(self) -> AutomationPattern[ExpandCollapsePattern]:
+        """Access the ExpandCollapse pattern.
+
+        :return: The ExpandCollapse pattern accessor.
+        """
+        return AutomationPattern[ExpandCollapsePattern](
+            raw_automation_pattern=self.raw_patterns.ExpandCollapse, pattern_type=ExpandCollapsePattern
+        )
+
+    @property
+    def grid(self) -> AutomationPattern[GridPattern]:
+        """Access the Grid pattern.
+
+        :return: The Grid pattern accessor.
+        """
+        return AutomationPattern[GridPattern](raw_automation_pattern=self.raw_patterns.Grid, pattern_type=GridPattern)

--- a/flaui/core/patterns/range_value_pattern.py
+++ b/flaui/core/patterns/range_value_pattern.py
@@ -1,0 +1,73 @@
+"""Wrapper for the UI Automation RangeValue pattern (``IRangeValuePattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class RangeValuePattern(PatternBase):
+    """Represents the UI Automation RangeValue pattern for controls with a numeric range (e.g. sliders)."""
+
+    @property
+    @handle_csharp_exceptions
+    def is_read_only(self) -> AutomationProperty:
+        """Return whether the value is read-only.
+
+        :return: An :class:`AutomationProperty` wrapping the read-only flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.IsReadOnly)
+
+    @property
+    @handle_csharp_exceptions
+    def large_change(self) -> AutomationProperty:
+        """Return the value added or subtracted on a large change.
+
+        :return: An :class:`AutomationProperty` wrapping the large-change amount.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.LargeChange)
+
+    @property
+    @handle_csharp_exceptions
+    def small_change(self) -> AutomationProperty:
+        """Return the value added or subtracted on a small change.
+
+        :return: An :class:`AutomationProperty` wrapping the small-change amount.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.SmallChange)
+
+    @property
+    @handle_csharp_exceptions
+    def maximum(self) -> AutomationProperty:
+        """Return the maximum value of the range.
+
+        :return: An :class:`AutomationProperty` wrapping the maximum value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.Maximum)
+
+    @property
+    @handle_csharp_exceptions
+    def minimum(self) -> AutomationProperty:
+        """Return the minimum value of the range.
+
+        :return: An :class:`AutomationProperty` wrapping the minimum value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.Minimum)
+
+    @property
+    @handle_csharp_exceptions
+    def value(self) -> AutomationProperty:
+        """Return the current value.
+
+        :return: An :class:`AutomationProperty` wrapping the current value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.Value)
+
+    @handle_csharp_exceptions
+    def set_value(self, value: float) -> None:
+        """Set the control's value.
+
+        :param value: The numeric value to set.
+        """
+        self.raw_pattern.SetValue(value)

--- a/flaui/core/patterns/toggle_pattern.py
+++ b/flaui/core/patterns/toggle_pattern.py
@@ -1,0 +1,25 @@
+"""Wrapper for the UI Automation Toggle pattern (``ITogglePattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class TogglePattern(PatternBase):
+    """Represents the UI Automation Toggle pattern for controls that cycle through states."""
+
+    @property
+    @handle_csharp_exceptions
+    def toggle_state(self) -> AutomationProperty:
+        """Return the current toggle state.
+
+        :return: An :class:`AutomationProperty` wrapping the ``ToggleState`` value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.ToggleState)
+
+    @handle_csharp_exceptions
+    def toggle(self) -> None:
+        """Cycle the control to its next toggle state."""
+        self.raw_pattern.Toggle()

--- a/flaui/core/patterns/value_pattern.py
+++ b/flaui/core/patterns/value_pattern.py
@@ -1,0 +1,37 @@
+"""Wrapper for the UI Automation Value pattern (``IValuePattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class ValuePattern(PatternBase):
+    """Represents the UI Automation Value pattern for reading and setting a control's text value."""
+
+    @property
+    @handle_csharp_exceptions
+    def is_read_only(self) -> AutomationProperty:
+        """Return whether the value is read-only.
+
+        :return: An :class:`AutomationProperty` wrapping the read-only flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.IsReadOnly)
+
+    @property
+    @handle_csharp_exceptions
+    def value(self) -> AutomationProperty:
+        """Return the current value.
+
+        :return: An :class:`AutomationProperty` wrapping the value string.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.Value)
+
+    @handle_csharp_exceptions
+    def set_value(self, value: str) -> None:
+        """Set the control's value.
+
+        :param value: The value to set.
+        """
+        self.raw_pattern.SetValue(value)

--- a/tests/ui/core/automation_elements/test_textbox.py
+++ b/tests/ui/core/automation_elements/test_textbox.py
@@ -48,7 +48,8 @@ class TestTextbox:
         if test_application_type == "WinForms":
             pytest.skip("WinForms currently does not report the color on text boxes")
 
-        text_range = textbox.patterns.Text.Pattern  # TODO: Check if we can add a C# wrapper to Python
+        # Text pattern is not yet wrapped; reach the native pattern via the raw escape hatch.
+        text_range = textbox.patterns.raw_patterns.Text.Pattern
         color_int = text_range.DocumentRange.GetAttributeValue(
             test_application.main_window.automation.text_attribute_library.ForegroundColor
         )

--- a/tests/ui/core/patterns/test_expand_collapse_pattern.py
+++ b/tests/ui/core/patterns/test_expand_collapse_pattern.py
@@ -51,14 +51,16 @@ class TestExpandCollapsePattern:
     def test_expander_pattern(self, expander: AutomationElement) -> None:
         """Test expand/collapse pattern on Expander control."""
         assert_that(expander, not_none())
-        ecp = expander.patterns.ExpandCollapse.Pattern  # TODO: Move Patterns to Py-wrapper once it is created
+        ecp = expander.patterns.expand_collapse.pattern
         assert_that(ecp, not_none())
-        assert ecp.ExpandCollapseState.Value == ExpandCollapseState.Collapsed.value, "Initial state should be collapsed"
-        ecp.Expand()
-        assert ecp.ExpandCollapseState.Value == ExpandCollapseState.Expanded.value, (
+        assert ecp.expand_collapse_state.value == ExpandCollapseState.Collapsed.value, (
+            "Initial state should be collapsed"
+        )
+        ecp.expand()
+        assert ecp.expand_collapse_state.value == ExpandCollapseState.Expanded.value, (
             "State should be expanded after expand()"
         )
-        ecp.Collapse()
-        assert ecp.ExpandCollapseState.Value == ExpandCollapseState.Collapsed.value, (
+        ecp.collapse()
+        assert ecp.expand_collapse_state.value == ExpandCollapseState.Collapsed.value, (
             "State should be collapsed after collapse()"
         )

--- a/tests/ui/core/patterns/test_grid_pattern.py
+++ b/tests/ui/core/patterns/test_grid_pattern.py
@@ -44,9 +44,9 @@ class TestGridPattern:
     def test_grid_pattern(self, data_grid: AutomationElement) -> None:
         """Test grid pattern on DataGrid control."""
         assert_that(data_grid, not_none())
-        grid_pattern = data_grid.patterns.Grid.Pattern  # TODO: Move Patterns to Py-wrapper once it is created
+        grid_pattern = data_grid.patterns.grid.pattern
         assert_that(grid_pattern, not_none())
-        assert grid_pattern.ColumnCount.Value == 3, "Column count should be 3"
-        assert grid_pattern.RowCount.Value == 3, "Row count should be 3"
-        item = grid_pattern.GetItem(1, 1)
-        assert item.Properties.Name.Value == "24", "Grid cell (1,1) should have value '24'"
+        assert grid_pattern.column_count.value == 3, "Column count should be 3"
+        assert grid_pattern.row_count.value == 3, "Row count should be 3"
+        item = grid_pattern.get_item(1, 1)
+        assert item.properties.name.value == "24", "Grid cell (1,1) should have value '24'"

--- a/tests/ui/core/patterns/test_invoke_pattern.py
+++ b/tests/ui/core/patterns/test_invoke_pattern.py
@@ -59,14 +59,12 @@ class TestInvokePattern:
         """
         assert_that(invokable_button, not_none())
         orig_button_text = invokable_button.properties.name  # noqa: F841
-        invoke_pattern = (
-            invokable_button.patterns.Invoke.Pattern
-        )  # TODO: Move Patterns to Py-wrapper once it is created
+        invoke_pattern = invokable_button.patterns.invoke.pattern
         assert_that(invoke_pattern, not_none())
 
         # TODO: Add event registration when RegisterAutomationEvent is ported
         # For now, just test basic invoke without event verification
-        invoke_pattern.Invoke()
+        invoke_pattern.invoke()
         # Button text should change after invoke (verification without event handler)
         # This may need refinement based on actual behavior
 

--- a/tests/ui/core/patterns/test_range_value_pattern.py
+++ b/tests/ui/core/patterns/test_range_value_pattern.py
@@ -4,6 +4,7 @@ Test for RangeValue pattern, ported from C# RangeValuePatternTests.cs.
 
 from typing import Any, Generator
 
+from dirty_equals import IsApprox
 from flaui.core.automation_elements import AutomationElement
 from flaui.core.condition_factory import ConditionFactory
 from hamcrest import assert_that, not_none
@@ -37,17 +38,24 @@ class TestRangeValuePattern:
     def test_range_value_pattern(self, slider: AutomationElement) -> None:
         """Test RangeValue pattern on Slider control."""
         assert_that(slider, not_none())
+        # UIA3 + WinForms normalizes the slider range to 0-100 (``is_only_value``); every
+        # other combination uses the configured 0-10 range. Scale expected values to match,
+        # mirroring ``TestSlider.adjust_number_if_only_value``.
+        scale = 10 if slider.as_slider().is_only_value else 1
         rv_pattern = slider.patterns.range_value.pattern
         assert_that(rv_pattern, not_none())
         assert not rv_pattern.is_read_only.value
-        assert rv_pattern.value.value == 5
-        assert rv_pattern.large_change.value == 4
-        assert rv_pattern.small_change.value == 1
+        assert rv_pattern.large_change.value == IsApprox(4 * scale, delta=0.1)
+        assert rv_pattern.small_change.value == IsApprox(1 * scale, delta=0.1)
         assert rv_pattern.minimum.value == 0
-        assert rv_pattern.maximum.value == 10
-        number1 = 6
+        assert rv_pattern.maximum.value == IsApprox(10 * scale, delta=0.1)
+        # The test application is shared across the session, so an earlier Slider test may
+        # have moved the thumb. Set a known baseline instead of assuming the default value.
+        rv_pattern.set_value(5 * scale)
+        assert rv_pattern.value.value == IsApprox(5 * scale, delta=0.1)
+        number1 = 6 * scale
         rv_pattern.set_value(number1)
-        assert rv_pattern.value.value == number1
-        number2 = 3
+        assert rv_pattern.value.value == IsApprox(number1, delta=0.1)
+        number2 = 3 * scale
         rv_pattern.set_value(number2)
-        assert rv_pattern.value.value == number2
+        assert rv_pattern.value.value == IsApprox(number2, delta=0.1)

--- a/tests/ui/core/patterns/test_range_value_pattern.py
+++ b/tests/ui/core/patterns/test_range_value_pattern.py
@@ -2,45 +2,52 @@
 Test for RangeValue pattern, ported from C# RangeValuePatternTests.cs.
 """
 
-# from flaui.core.automation_elements import AutomationElement
-# from flaui.core.condition_factory import ConditionFactory
-# from hamcrest import assert_that, not_none
-# import pytest
+from typing import Any, Generator
 
-# from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
-# from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.condition_factory import ConditionFactory
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
 
 
-# @pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
-# class TestRangeValuePattern:
-#     """Tests for RangeValue pattern on Slider control."""
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestRangeValuePattern:
+    """Tests for RangeValue pattern on Slider control."""
 
-#     @pytest.fixture(name="slider")
-#     def get_slider(
-#         self,
-#         test_application: WinFormsApplicationElements | WPFApplicationElements,
-#         condition_factory: ConditionFactory,
-#     ):
-#         """Fixture to get the Slider element."""
-#         slider = test_application.main_window.find_first_descendant(
-#             condition=condition_factory.by_automation_id("Slider")
-#         )
-#         return slider
+    @pytest.fixture(name="slider")
+    def get_slider(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+        condition_factory: ConditionFactory,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the Slider element.
 
-#     def test_range_value_pattern(self, slider: AutomationElement):
-#         """Test RangeValue pattern on Slider control."""
-#         assert_that(slider, not_none())
-#         rv_pattern = slider.patterns.RangeValue.Pattern  # TODO: Move Patterns to Py-wrapper once it is created
-#         assert_that(rv_pattern, not_none())
-#         assert not rv_pattern.IsReadOnly.Value
-#         assert rv_pattern.Value.Value == 5
-#         assert rv_pattern.LargeChange.Value == 4
-#         assert rv_pattern.SmallChange.Value == 1
-#         assert rv_pattern.Minimum.Value == 0
-#         assert rv_pattern.Maximum.Value == 10
-#         number1 = 6
-#         rv_pattern.SetValue(number1)
-#         assert rv_pattern.Value.Value == number1
-#         number2 = 3
-#         rv_pattern.SetValue(number2)
-#         assert rv_pattern.Value.Value == number2
+        :param test_application: Test application elements.
+        :param condition_factory: Condition factory for building search conditions.
+        :yield: Slider automation element.
+        """
+        slider = test_application.main_window.find_first_descendant(
+            condition=condition_factory.by_automation_id("Slider")
+        )
+        yield slider
+
+    def test_range_value_pattern(self, slider: AutomationElement) -> None:
+        """Test RangeValue pattern on Slider control."""
+        assert_that(slider, not_none())
+        rv_pattern = slider.patterns.range_value.pattern
+        assert_that(rv_pattern, not_none())
+        assert not rv_pattern.is_read_only.value
+        assert rv_pattern.value.value == 5
+        assert rv_pattern.large_change.value == 4
+        assert rv_pattern.small_change.value == 1
+        assert rv_pattern.minimum.value == 0
+        assert rv_pattern.maximum.value == 10
+        number1 = 6
+        rv_pattern.set_value(number1)
+        assert rv_pattern.value.value == number1
+        number2 = 3
+        rv_pattern.set_value(number2)
+        assert rv_pattern.value.value == number2

--- a/tests/unit/core/test_patterns_architecture.py
+++ b/tests/unit/core/test_patterns_architecture.py
@@ -1,0 +1,86 @@
+"""Unit tests for the pattern-access architecture (``flaui.core.patterns``).
+
+These exercise the wrapper plumbing with lightweight fakes, so they need no running UI: a
+``SimpleNamespace`` stands in for the native C# ``IAutomationPattern<T>`` / pattern objects.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.patterns import AutomationPattern, InvokePattern, ValuePattern
+from flaui.lib.exceptions import PatternNotSupportedException
+
+
+class TestPatternBase:
+    """Validate the shared pattern base behaviour."""
+
+    def test_none_raw_pattern_rejected(self) -> None:
+        """Constructing a pattern with a missing native object raises ``PatternNotSupportedException``."""
+        with pytest.raises(PatternNotSupportedException):
+            InvokePattern(raw_pattern=None)
+
+    def test_raw_pattern_is_exposed(self) -> None:
+        """The native pattern object is reachable via ``raw_pattern`` as an escape hatch."""
+        native = SimpleNamespace()
+        assert InvokePattern(raw_pattern=native).raw_pattern is native
+
+
+class TestAutomationPattern:
+    """Validate the ``IAutomationPattern<T>`` accessor wrapper."""
+
+    @staticmethod
+    def _accessor(supported: bool, native: object) -> AutomationPattern[InvokePattern]:
+        """Build an accessor backed by a fake native ``IAutomationPattern<T>``."""
+        raw = SimpleNamespace(
+            IsSupported=supported,
+            Pattern=native,
+            PatternOrDefault=native if supported else None,
+        )
+        return AutomationPattern[InvokePattern](raw_automation_pattern=raw, pattern_type=InvokePattern)
+
+    def test_is_supported_reflects_native(self) -> None:
+        """``is_supported`` reads the native ``IsSupported`` flag."""
+        assert self._accessor(True, SimpleNamespace()).is_supported is True
+        assert self._accessor(False, None).is_supported is False
+
+    def test_pattern_wraps_native(self) -> None:
+        """``pattern`` wraps the native pattern in the configured Python class."""
+        native = SimpleNamespace()
+        wrapped = self._accessor(True, native).pattern
+        assert isinstance(wrapped, InvokePattern)
+        assert wrapped.raw_pattern is native
+
+    def test_pattern_or_default_none_when_unsupported(self) -> None:
+        """``pattern_or_default`` returns ``None`` when the pattern is unsupported."""
+        assert self._accessor(False, None).pattern_or_default is None
+
+    def test_try_get_pattern(self) -> None:
+        """``try_get_pattern`` reports support and returns the wrapped pattern."""
+        supported, wrapped = self._accessor(True, SimpleNamespace()).try_get_pattern()
+        assert supported is True
+        assert isinstance(wrapped, InvokePattern)
+
+        unsupported, missing = self._accessor(False, None).try_get_pattern()
+        assert unsupported is False
+        assert missing is None
+
+
+class TestPatternProperties:
+    """Validate that pattern properties surface as ``AutomationProperty`` wrappers."""
+
+    def test_value_pattern_exposes_automation_properties(self) -> None:
+        """``ValuePattern`` wraps its native properties as :class:`AutomationProperty`."""
+        native = SimpleNamespace(Value=SimpleNamespace(Value="hello"), IsReadOnly=SimpleNamespace(Value=False))
+        pattern = ValuePattern(raw_pattern=native)
+        assert isinstance(pattern.value, AutomationProperty)
+        assert pattern.value.value == "hello"
+        assert pattern.is_read_only.value is False
+
+    def test_value_pattern_set_value_delegates_to_native(self) -> None:
+        """``set_value`` forwards to the native ``SetValue``."""
+        captured = {}
+        native = SimpleNamespace(SetValue=lambda v: captured.setdefault("value", v))
+        ValuePattern(raw_pattern=native).set_value("typed")
+        assert captured["value"] == "typed"

--- a/zensical.toml
+++ b/zensical.toml
@@ -27,6 +27,7 @@ nav = [
       { "Condition Factory" = "api/condition_factory.md" },
       { "Automation Element" = "api/automation_element.md" },
       { "Identifiers" = "api/identifiers.md" },
+      { "Patterns" = "api/patterns.md" },
     ] },
     { "Input" = [
       { "Mouse" = "api/mouse.md" },


### PR DESCRIPTION
## Summary
Establishes the **pattern-access architecture** for Phase 2 (#91) — the largest gap between the Python port and C# FlaUI — and ports the first pattern family. Mirrors `FlaUI.Core.Patterns` one-to-one.

### Architecture (`flaui/core/patterns/`)
- **`PatternBase`** — Pydantic wrapper over a native C# pattern object; `raw_pattern` is the escape hatch for members not yet wrapped.
- **`AutomationPattern[T]`** — wraps C# `IAutomationPattern<T>`: `.pattern`, `.pattern_or_default`, `.is_supported`, `.try_get_pattern()`.
- **`Patterns` facade** (`element.patterns`) — typed, snake_case access mirroring C#:
  ```python
  element.patterns.value.pattern.value.value   # C#: element.Patterns.Value.Pattern.Value.Value
  element.patterns.toggle.is_supported          # C#: element.Patterns.Toggle.IsSupported
  ```

### First family ported
Invoke, Toggle, Value, RangeValue, ExpandCollapse, Grid.

### Behavior change
`element.patterns` now returns the typed facade instead of the raw C# object. The raw object stays reachable via `element.patterns.raw_patterns`. The existing convenience mixins (`ToggleAutomationElement`, etc.) are untouched.

### Tests / docs
- Migrated the existing pattern UI tests (expand_collapse, grid, invoke) to the new API; un-commented + ported the RangeValue test.
- 8 new unit tests covering the wrapper plumbing with fakes (no UI required).
- New `docs/api/patterns.md` + nav entry.

## Verification
- `ruff check` / `ruff format` clean
- `interrogate` 100%
- 8 unit tests + 8 UI pattern tests pass locally (4 WinForms-only skips); textbox test green via raw escape hatch
- Strict Zensical build green

Part of #91 (remaining families to follow in incremental PRs: grid/table/scroll/selection, text/window/transform/dock, then the long tail).
