### PR TITLE
feat(patterns): Text/Window/Transform/Dock pattern family (GH-91)

### DIFF
--- a/docs/api/patterns.md
+++ b/docs/api/patterns.md
@@ -16,3 +16,10 @@ Each pattern wraps a native C# pattern object, always reachable via `raw_pattern
 hatch for members that are not yet wrapped. Patterns are ported incrementally by family.
 
 ::: flaui.core.patterns
+
+## Text ranges
+
+The Text patterns (`TextPattern`, `Text2Pattern`, `TextEditPattern`, `TextChildPattern`) return
+`TextRange` objects, the Python wrapper around C# `ITextRange`.
+
+::: flaui.core.text_range

--- a/flaui/core/definitions.py
+++ b/flaui/core/definitions.py
@@ -8,13 +8,20 @@ from enum import Enum
 from FlaUI.Core.Definitions import (  # pyright: ignore
     AutomationElementMode as CSAutomationElementMode,
     ControlType as CSControlType,
+    DockPosition as CSDockPosition,
     ExpandCollapseState as CSExpandCollapseState,
     PropertyConditionFlags as CSPropertyConditionFlags,
     RowOrColumnMajor as CSRowOrColumnMajor,
     ScrollAmount as CSScrollAmount,
+    SupportedTextSelection as CSSupportedTextSelection,
+    TextPatternRangeEndpoint as CSTextPatternRangeEndpoint,
+    TextUnit as CSTextUnit,
     ToggleState as CSToggleState,
     TreeScope as CSTreeScope,
     TreeTraversalOptions as CSTreeTraversalOptions,
+    WindowInteractionState as CSWindowInteractionState,
+    WindowVisualState as CSWindowVisualState,
+    ZoomUnit as CSZoomUnit,
 )
 
 
@@ -157,3 +164,69 @@ class TreeTraversalOptions(Enum):
     Default = CSTreeTraversalOptions.Default
     PostOrder = CSTreeTraversalOptions.PostOrder
     LastToFirstOrder = CSTreeTraversalOptions.LastToFirstOrder
+
+
+class WindowVisualState(Enum):
+    """Contains values that specify the visual state of a window."""
+
+    Normal = CSWindowVisualState.Normal
+    Maximized = CSWindowVisualState.Maximized
+    Minimized = CSWindowVisualState.Minimized
+
+
+class WindowInteractionState(Enum):
+    """Contains values that specify the current state of a window for user interaction."""
+
+    Running = CSWindowInteractionState.Running
+    Closing = CSWindowInteractionState.Closing
+    ReadyForUserInteraction = CSWindowInteractionState.ReadyForUserInteraction
+    BlockedByModalWindow = CSWindowInteractionState.BlockedByModalWindow
+    NotResponding = CSWindowInteractionState.NotResponding
+
+
+class DockPosition(Enum):
+    """Contains values that specify the dock position of an element within a docking container."""
+
+    Top = CSDockPosition.Top
+    Left = CSDockPosition.Left
+    Bottom = CSDockPosition.Bottom
+    Right = CSDockPosition.Right
+    Fill = CSDockPosition.Fill
+    None_ = getattr(CSDockPosition, "None")
+
+
+class ZoomUnit(Enum):
+    """Contains values that specify the amount to zoom on a control."""
+
+    NoAmount = CSZoomUnit.NoAmount
+    LargeDecrement = CSZoomUnit.LargeDecrement
+    SmallDecrement = CSZoomUnit.SmallDecrement
+    LargeIncrement = CSZoomUnit.LargeIncrement
+    SmallIncrement = CSZoomUnit.SmallIncrement
+
+
+class SupportedTextSelection(Enum):
+    """Contains values that specify the supported text selection attribute of a text control."""
+
+    None_ = getattr(CSSupportedTextSelection, "None")
+    Single = CSSupportedTextSelection.Single
+    Multiple = CSSupportedTextSelection.Multiple
+
+
+class TextPatternRangeEndpoint(Enum):
+    """Contains values that specify the endpoints of a text range."""
+
+    Start = CSTextPatternRangeEndpoint.Start
+    End = CSTextPatternRangeEndpoint.End
+
+
+class TextUnit(Enum):
+    """Contains values that specify units of text for the purposes of navigation."""
+
+    Character = CSTextUnit.Character
+    Format = CSTextUnit.Format
+    Word = CSTextUnit.Word
+    Line = CSTextUnit.Line
+    Paragraph = CSTextUnit.Paragraph
+    Page = CSTextUnit.Page
+    Document = CSTextUnit.Document

--- a/flaui/core/patterns/__init__.py
+++ b/flaui/core/patterns/__init__.py
@@ -9,6 +9,7 @@ Patterns are ported incrementally by family; this module re-exports the ones ava
 """
 
 from flaui.core.patterns.automation_pattern import AutomationPattern
+from flaui.core.patterns.dock_pattern import DockPattern
 from flaui.core.patterns.expand_collapse_pattern import ExpandCollapsePattern
 from flaui.core.patterns.grid_item_pattern import GridItemPattern
 from flaui.core.patterns.grid_pattern import GridPattern
@@ -23,11 +24,19 @@ from flaui.core.patterns.selection_item_pattern import SelectionItemPattern
 from flaui.core.patterns.selection_pattern import SelectionPattern
 from flaui.core.patterns.table_item_pattern import TableItemPattern
 from flaui.core.patterns.table_pattern import TablePattern
+from flaui.core.patterns.text2_pattern import Text2Pattern
+from flaui.core.patterns.text_child_pattern import TextChildPattern
+from flaui.core.patterns.text_edit_pattern import TextEditPattern
+from flaui.core.patterns.text_pattern import TextPattern
 from flaui.core.patterns.toggle_pattern import TogglePattern
+from flaui.core.patterns.transform2_pattern import Transform2Pattern
+from flaui.core.patterns.transform_pattern import TransformPattern
 from flaui.core.patterns.value_pattern import ValuePattern
+from flaui.core.patterns.window_pattern import WindowPattern
 
 __all__ = [
     "AutomationPattern",
+    "DockPattern",
     "ExpandCollapsePattern",
     "GridItemPattern",
     "GridPattern",
@@ -42,6 +51,13 @@ __all__ = [
     "SelectionPattern",
     "TableItemPattern",
     "TablePattern",
+    "Text2Pattern",
+    "TextChildPattern",
+    "TextEditPattern",
+    "TextPattern",
     "TogglePattern",
+    "Transform2Pattern",
+    "TransformPattern",
     "ValuePattern",
+    "WindowPattern",
 ]

--- a/flaui/core/patterns/dock_pattern.py
+++ b/flaui/core/patterns/dock_pattern.py
@@ -1,0 +1,29 @@
+"""Wrapper for the UI Automation Dock pattern (``IDockPattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.definitions import DockPosition
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class DockPattern(PatternBase):
+    """Represents the UI Automation Dock pattern for controls docked within a docking container."""
+
+    @property
+    @handle_csharp_exceptions
+    def dock_position(self) -> AutomationProperty:
+        """Return the control's current dock position.
+
+        :return: An :class:`AutomationProperty` wrapping the ``DockPosition`` value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.DockPosition)
+
+    @handle_csharp_exceptions
+    def set_dock_position(self, dock_position: DockPosition) -> None:
+        """Set the control's dock position.
+
+        :param dock_position: The desired dock position.
+        """
+        self.raw_pattern.SetDockPosition(dock_position.value)

--- a/flaui/core/patterns/patterns.py
+++ b/flaui/core/patterns/patterns.py
@@ -18,6 +18,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from flaui.core.patterns.automation_pattern import AutomationPattern
+from flaui.core.patterns.dock_pattern import DockPattern
 from flaui.core.patterns.expand_collapse_pattern import ExpandCollapsePattern
 from flaui.core.patterns.grid_item_pattern import GridItemPattern
 from flaui.core.patterns.grid_pattern import GridPattern
@@ -30,8 +31,15 @@ from flaui.core.patterns.selection_item_pattern import SelectionItemPattern
 from flaui.core.patterns.selection_pattern import SelectionPattern
 from flaui.core.patterns.table_item_pattern import TableItemPattern
 from flaui.core.patterns.table_pattern import TablePattern
+from flaui.core.patterns.text2_pattern import Text2Pattern
+from flaui.core.patterns.text_child_pattern import TextChildPattern
+from flaui.core.patterns.text_edit_pattern import TextEditPattern
+from flaui.core.patterns.text_pattern import TextPattern
 from flaui.core.patterns.toggle_pattern import TogglePattern
+from flaui.core.patterns.transform2_pattern import Transform2Pattern
+from flaui.core.patterns.transform_pattern import TransformPattern
 from flaui.core.patterns.value_pattern import ValuePattern
+from flaui.core.patterns.window_pattern import WindowPattern
 
 
 class Patterns(BaseModel):
@@ -178,3 +186,79 @@ class Patterns(BaseModel):
         return AutomationPattern[SelectionItemPattern](
             raw_automation_pattern=self.raw_patterns.SelectionItem, pattern_type=SelectionItemPattern
         )
+
+    @property
+    def text(self) -> AutomationPattern[TextPattern]:
+        """Access the Text pattern.
+
+        :return: The Text pattern accessor.
+        """
+        return AutomationPattern[TextPattern](raw_automation_pattern=self.raw_patterns.Text, pattern_type=TextPattern)
+
+    @property
+    def text2(self) -> AutomationPattern[Text2Pattern]:
+        """Access the Text2 pattern.
+
+        :return: The Text2 pattern accessor.
+        """
+        return AutomationPattern[Text2Pattern](
+            raw_automation_pattern=self.raw_patterns.Text2, pattern_type=Text2Pattern
+        )
+
+    @property
+    def text_edit(self) -> AutomationPattern[TextEditPattern]:
+        """Access the TextEdit pattern.
+
+        :return: The TextEdit pattern accessor.
+        """
+        return AutomationPattern[TextEditPattern](
+            raw_automation_pattern=self.raw_patterns.TextEdit, pattern_type=TextEditPattern
+        )
+
+    @property
+    def text_child(self) -> AutomationPattern[TextChildPattern]:
+        """Access the TextChild pattern.
+
+        :return: The TextChild pattern accessor.
+        """
+        return AutomationPattern[TextChildPattern](
+            raw_automation_pattern=self.raw_patterns.TextChild, pattern_type=TextChildPattern
+        )
+
+    @property
+    def window(self) -> AutomationPattern[WindowPattern]:
+        """Access the Window pattern.
+
+        :return: The Window pattern accessor.
+        """
+        return AutomationPattern[WindowPattern](
+            raw_automation_pattern=self.raw_patterns.Window, pattern_type=WindowPattern
+        )
+
+    @property
+    def transform(self) -> AutomationPattern[TransformPattern]:
+        """Access the Transform pattern.
+
+        :return: The Transform pattern accessor.
+        """
+        return AutomationPattern[TransformPattern](
+            raw_automation_pattern=self.raw_patterns.Transform, pattern_type=TransformPattern
+        )
+
+    @property
+    def transform2(self) -> AutomationPattern[Transform2Pattern]:
+        """Access the Transform2 pattern.
+
+        :return: The Transform2 pattern accessor.
+        """
+        return AutomationPattern[Transform2Pattern](
+            raw_automation_pattern=self.raw_patterns.Transform2, pattern_type=Transform2Pattern
+        )
+
+    @property
+    def dock(self) -> AutomationPattern[DockPattern]:
+        """Access the Dock pattern.
+
+        :return: The Dock pattern accessor.
+        """
+        return AutomationPattern[DockPattern](raw_automation_pattern=self.raw_patterns.Dock, pattern_type=DockPattern)

--- a/flaui/core/patterns/text2_pattern.py
+++ b/flaui/core/patterns/text2_pattern.py
@@ -1,0 +1,34 @@
+"""Wrapper for the UI Automation Text2 pattern (``IText2Pattern``)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+from flaui.core.patterns.text_pattern import TextPattern
+from flaui.core.text_range import TextRange
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+if TYPE_CHECKING:
+    from flaui.core.automation_elements import AutomationElement
+
+
+class Text2Pattern(TextPattern):
+    """Extends the Text pattern with caret and annotation range lookups."""
+
+    @handle_csharp_exceptions
+    def get_caret_range(self) -> Tuple[TextRange, bool]:
+        """Return the text range of the caret and whether the caret is active.
+
+        :return: A tuple ``(caret_range, is_active)``.
+        """
+        raw_range, is_active = self.raw_pattern.GetCaretRange()
+        return TextRange(raw_text_range=raw_range), is_active
+
+    @handle_csharp_exceptions
+    def range_from_annotation(self, annotation: "AutomationElement") -> TextRange:
+        """Return the text range associated with an annotation element.
+
+        :param annotation: The annotation element.
+        :return: A :class:`~flaui.core.text_range.TextRange` for the annotation.
+        """
+        return TextRange(raw_text_range=self.raw_pattern.RangeFromAnnotation(annotation.raw_element))

--- a/flaui/core/patterns/text_child_pattern.py
+++ b/flaui/core/patterns/text_child_pattern.py
@@ -1,0 +1,33 @@
+"""Wrapper for the UI Automation TextChild pattern (``ITextChildPattern``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.core.text_range import TextRange
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class TextChildPattern(PatternBase):
+    """Represents the UI Automation TextChild pattern for elements embedded inside text content."""
+
+    @property
+    @handle_csharp_exceptions
+    def text_container(self) -> Any:
+        """Return the nearest ancestor that supports the Text pattern.
+
+        :return: The containing :class:`~flaui.core.automation_elements.AutomationElement`.
+        """
+        from flaui.core.automation_elements import AutomationElement
+
+        return AutomationElement(raw_element=self.raw_pattern.TextContainer)
+
+    @property
+    @handle_csharp_exceptions
+    def text_range(self) -> TextRange:
+        """Return the text range that encloses this child element.
+
+        :return: A :class:`~flaui.core.text_range.TextRange` for the element.
+        """
+        return TextRange(raw_text_range=self.raw_pattern.TextRange)

--- a/flaui/core/patterns/text_edit_pattern.py
+++ b/flaui/core/patterns/text_edit_pattern.py
@@ -1,0 +1,31 @@
+"""Wrapper for the UI Automation TextEdit pattern (``ITextEditPattern``)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from flaui.core.patterns.text_pattern import TextPattern
+from flaui.core.text_range import TextRange
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class TextEditPattern(TextPattern):
+    """Extends the Text pattern with access to in-progress text composition (IME) ranges."""
+
+    @handle_csharp_exceptions
+    def get_active_composition(self) -> Optional[TextRange]:
+        """Return the text range of the active text composition, if any.
+
+        :return: The active composition :class:`~flaui.core.text_range.TextRange`, or ``None``.
+        """
+        result = self.raw_pattern.GetActiveComposition()
+        return None if result is None else TextRange(raw_text_range=result)
+
+    @handle_csharp_exceptions
+    def get_conversion_target(self) -> Optional[TextRange]:
+        """Return the text range of the current conversion target, if any.
+
+        :return: The conversion target :class:`~flaui.core.text_range.TextRange`, or ``None``.
+        """
+        result = self.raw_pattern.GetConversionTarget()
+        return None if result is None else TextRange(raw_text_range=result)

--- a/flaui/core/patterns/text_pattern.py
+++ b/flaui/core/patterns/text_pattern.py
@@ -1,0 +1,70 @@
+"""Wrapper for the UI Automation Text pattern (``ITextPattern``)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from flaui.core.definitions import SupportedTextSelection
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.core.text_range import TextRange
+from flaui.lib.exceptions import handle_csharp_exceptions
+from flaui.lib.system.drawing import Point
+
+if TYPE_CHECKING:
+    from flaui.core.automation_elements import AutomationElement
+
+
+class TextPattern(PatternBase):
+    """Represents the UI Automation Text pattern for controls that expose rich text content."""
+
+    @property
+    @handle_csharp_exceptions
+    def document_range(self) -> TextRange:
+        """Return a text range spanning the entire document.
+
+        :return: A :class:`~flaui.core.text_range.TextRange` over the whole document.
+        """
+        return TextRange(raw_text_range=self.raw_pattern.DocumentRange)
+
+    @property
+    @handle_csharp_exceptions
+    def supported_text_selection(self) -> SupportedTextSelection:
+        """Return the kind of text selection the control supports.
+
+        :return: The supported text selection mode.
+        """
+        return SupportedTextSelection(self.raw_pattern.SupportedTextSelection)
+
+    @handle_csharp_exceptions
+    def get_selection(self) -> List[TextRange]:
+        """Return the currently selected text ranges.
+
+        :return: A list of selected :class:`~flaui.core.text_range.TextRange` objects.
+        """
+        return [TextRange(raw_text_range=_) for _ in self.raw_pattern.GetSelection()]
+
+    @handle_csharp_exceptions
+    def get_visible_ranges(self) -> List[TextRange]:
+        """Return the text ranges that are currently visible.
+
+        :return: A list of visible :class:`~flaui.core.text_range.TextRange` objects.
+        """
+        return [TextRange(raw_text_range=_) for _ in self.raw_pattern.GetVisibleRanges()]
+
+    @handle_csharp_exceptions
+    def range_from_child(self, child: "AutomationElement") -> TextRange:
+        """Return the text range that encloses a child element.
+
+        :param child: The child element to locate.
+        :return: A :class:`~flaui.core.text_range.TextRange` enclosing the child.
+        """
+        return TextRange(raw_text_range=self.raw_pattern.RangeFromChild(child.raw_element))
+
+    @handle_csharp_exceptions
+    def range_from_point(self, point: Point) -> TextRange:
+        """Return the degenerate text range nearest to a screen point.
+
+        :param point: The screen point to locate.
+        :return: A :class:`~flaui.core.text_range.TextRange` at the point.
+        """
+        return TextRange(raw_text_range=self.raw_pattern.RangeFromPoint(point.cs_object))

--- a/flaui/core/patterns/transform2_pattern.py
+++ b/flaui/core/patterns/transform2_pattern.py
@@ -1,0 +1,64 @@
+"""Wrapper for the UI Automation Transform2 pattern (``ITransform2Pattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.definitions import ZoomUnit
+from flaui.core.patterns.transform_pattern import TransformPattern
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class Transform2Pattern(TransformPattern):
+    """Extends the Transform pattern with zoom capabilities."""
+
+    @property
+    @handle_csharp_exceptions
+    def can_zoom(self) -> AutomationProperty:
+        """Return whether the control can be zoomed.
+
+        :return: An :class:`AutomationProperty` wrapping the can-zoom flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.CanZoom)
+
+    @property
+    @handle_csharp_exceptions
+    def zoom_level(self) -> AutomationProperty:
+        """Return the current zoom level.
+
+        :return: An :class:`AutomationProperty` wrapping the zoom level.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.ZoomLevel)
+
+    @property
+    @handle_csharp_exceptions
+    def zoom_maximum(self) -> AutomationProperty:
+        """Return the maximum zoom level.
+
+        :return: An :class:`AutomationProperty` wrapping the maximum zoom level.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.ZoomMaximum)
+
+    @property
+    @handle_csharp_exceptions
+    def zoom_minimum(self) -> AutomationProperty:
+        """Return the minimum zoom level.
+
+        :return: An :class:`AutomationProperty` wrapping the minimum zoom level.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.ZoomMinimum)
+
+    @handle_csharp_exceptions
+    def zoom(self, zoom: float) -> None:
+        """Zoom the control to the given level.
+
+        :param zoom: The target zoom level.
+        """
+        self.raw_pattern.Zoom(zoom)
+
+    @handle_csharp_exceptions
+    def zoom_by_unit(self, zoom_unit: ZoomUnit) -> None:
+        """Zoom the control by a discrete unit.
+
+        :param zoom_unit: The zoom unit (increment/decrement amount).
+        """
+        self.raw_pattern.ZoomByUnit(zoom_unit.value)

--- a/flaui/core/patterns/transform_pattern.py
+++ b/flaui/core/patterns/transform_pattern.py
@@ -1,0 +1,64 @@
+"""Wrapper for the UI Automation Transform pattern (``ITransformPattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class TransformPattern(PatternBase):
+    """Represents the UI Automation Transform pattern for movable, resizable, rotatable controls."""
+
+    @property
+    @handle_csharp_exceptions
+    def can_move(self) -> AutomationProperty:
+        """Return whether the control can be moved.
+
+        :return: An :class:`AutomationProperty` wrapping the can-move flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.CanMove)
+
+    @property
+    @handle_csharp_exceptions
+    def can_resize(self) -> AutomationProperty:
+        """Return whether the control can be resized.
+
+        :return: An :class:`AutomationProperty` wrapping the can-resize flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.CanResize)
+
+    @property
+    @handle_csharp_exceptions
+    def can_rotate(self) -> AutomationProperty:
+        """Return whether the control can be rotated.
+
+        :return: An :class:`AutomationProperty` wrapping the can-rotate flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.CanRotate)
+
+    @handle_csharp_exceptions
+    def move(self, x: float, y: float) -> None:
+        """Move the control to the given screen coordinates.
+
+        :param x: The target x-coordinate.
+        :param y: The target y-coordinate.
+        """
+        self.raw_pattern.Move(x, y)
+
+    @handle_csharp_exceptions
+    def resize(self, width: float, height: float) -> None:
+        """Resize the control to the given dimensions.
+
+        :param width: The target width.
+        :param height: The target height.
+        """
+        self.raw_pattern.Resize(width, height)
+
+    @handle_csharp_exceptions
+    def rotate(self, degrees: float) -> None:
+        """Rotate the control by the given number of degrees.
+
+        :param degrees: The rotation in degrees.
+        """
+        self.raw_pattern.Rotate(degrees)

--- a/flaui/core/patterns/window_pattern.py
+++ b/flaui/core/patterns/window_pattern.py
@@ -1,0 +1,88 @@
+"""Wrapper for the UI Automation Window pattern (``IWindowPattern``)."""
+
+from __future__ import annotations
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.definitions import WindowVisualState
+from flaui.core.patterns.pattern_base import PatternBase
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+
+class WindowPattern(PatternBase):
+    """Represents the UI Automation Window pattern for top-level and child windows."""
+
+    @property
+    @handle_csharp_exceptions
+    def can_maximize(self) -> AutomationProperty:
+        """Return whether the window can be maximized.
+
+        :return: An :class:`AutomationProperty` wrapping the can-maximize flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.CanMaximize)
+
+    @property
+    @handle_csharp_exceptions
+    def can_minimize(self) -> AutomationProperty:
+        """Return whether the window can be minimized.
+
+        :return: An :class:`AutomationProperty` wrapping the can-minimize flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.CanMinimize)
+
+    @property
+    @handle_csharp_exceptions
+    def is_modal(self) -> AutomationProperty:
+        """Return whether the window is modal.
+
+        :return: An :class:`AutomationProperty` wrapping the modal flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.IsModal)
+
+    @property
+    @handle_csharp_exceptions
+    def is_topmost(self) -> AutomationProperty:
+        """Return whether the window is top-most.
+
+        :return: An :class:`AutomationProperty` wrapping the top-most flag.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.IsTopmost)
+
+    @property
+    @handle_csharp_exceptions
+    def window_interaction_state(self) -> AutomationProperty:
+        """Return the window's current interaction state.
+
+        :return: An :class:`AutomationProperty` wrapping the ``WindowInteractionState`` value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.WindowInteractionState)
+
+    @property
+    @handle_csharp_exceptions
+    def window_visual_state(self) -> AutomationProperty:
+        """Return the window's current visual state.
+
+        :return: An :class:`AutomationProperty` wrapping the ``WindowVisualState`` value.
+        """
+        return AutomationProperty(raw_property=self.raw_pattern.WindowVisualState)
+
+    @handle_csharp_exceptions
+    def close(self) -> None:
+        """Close the window."""
+        self.raw_pattern.Close()
+
+    @handle_csharp_exceptions
+    def set_window_visual_state(self, state: WindowVisualState) -> None:
+        """Set the window's visual state.
+
+        :param state: The desired visual state (normal, maximized, or minimized).
+        """
+        self.raw_pattern.SetWindowVisualState(state.value)
+
+    @handle_csharp_exceptions
+    def wait_for_input_idle(self, milliseconds: int) -> bool:
+        """Wait until the window is ready to accept input, or the timeout elapses.
+
+        :param milliseconds: The maximum time to wait, in milliseconds.
+        :return: ``True`` if the window became idle within the timeout, else ``False``.
+        """
+        return self.raw_pattern.WaitForInputIdle(milliseconds)

--- a/flaui/core/text_range.py
+++ b/flaui/core/text_range.py
@@ -1,0 +1,209 @@
+"""Python wrapper for the C# ``FlaUI.Core.ITextRange`` type.
+
+A text range represents a contiguous span of text within a control that supports the Text pattern.
+The wrapper mirrors ``ITextRange`` one-to-one; the native object stays reachable via
+:attr:`TextRange.raw_text_range`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+from flaui.core.definitions import TextPatternRangeEndpoint, TextUnit
+from flaui.lib.exceptions import ElementNotFound, handle_csharp_exceptions
+from flaui.lib.system.drawing import Rectangle
+
+
+class TextRange(BaseModel):
+    """Represents a span of text within a Text-pattern control (mirrors C# ``ITextRange``)."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    raw_text_range: Any = Field(..., description="The underlying C# ITextRange object")
+
+    @field_validator("raw_text_range")
+    def validate_text_range_exists(cls, v: Any, info: ValidationInfo) -> Any:
+        """Validate the native text range exists.
+
+        :param v: Raw C# ITextRange object.
+        :param info: Pydantic validation info.
+        :raises ElementNotFound: If the text range is ``None``.
+        :return: The validated raw text range.
+        """
+        if v is None:
+            raise ElementNotFound("Text range does not exist")
+        return v
+
+    @handle_csharp_exceptions
+    def add_to_selection(self) -> None:
+        """Add the text range to the current selection."""
+        self.raw_text_range.AddToSelection()
+
+    @handle_csharp_exceptions
+    def clone(self) -> "TextRange":
+        """Return a copy of the text range.
+
+        :return: A new :class:`TextRange` with the same span.
+        """
+        return TextRange(raw_text_range=self.raw_text_range.Clone())
+
+    @handle_csharp_exceptions
+    def compare(self, range: "TextRange") -> bool:
+        """Return whether this range spans the same text as another.
+
+        :param range: The range to compare against.
+        :return: ``True`` if both ranges have identical endpoints.
+        """
+        return self.raw_text_range.Compare(range.raw_text_range)
+
+    @handle_csharp_exceptions
+    def compare_endpoints(
+        self,
+        src_endpoint: TextPatternRangeEndpoint,
+        target_range: "TextRange",
+        target_endpoint: TextPatternRangeEndpoint,
+    ) -> int:
+        """Compare an endpoint of this range with an endpoint of another range.
+
+        :param src_endpoint: The endpoint of this range to compare.
+        :param target_range: The other range.
+        :param target_endpoint: The endpoint of the other range to compare.
+        :return: Negative, zero, or positive if this endpoint is before, at, or after the target.
+        """
+        return self.raw_text_range.CompareEndpoints(
+            src_endpoint.value, target_range.raw_text_range, target_endpoint.value
+        )
+
+    @handle_csharp_exceptions
+    def expand_to_enclosing_unit(self, text_unit: TextUnit) -> None:
+        """Expand the range to the nearest enclosing unit boundary.
+
+        :param text_unit: The text unit to expand to.
+        """
+        self.raw_text_range.ExpandToEnclosingUnit(text_unit.value)
+
+    @handle_csharp_exceptions
+    def find_attribute(self, attribute: Any, value: Any, backward: bool) -> Optional["TextRange"]:
+        """Find a sub-range with the given text attribute value.
+
+        :param attribute: The C# ``TextAttributeId`` to search for.
+        :param value: The attribute value to match.
+        :param backward: Search backward from the end when ``True``.
+        :return: The matching :class:`TextRange`, or ``None`` if not found.
+        """
+        result = self.raw_text_range.FindAttribute(attribute, value, backward)
+        return None if result is None else TextRange(raw_text_range=result)
+
+    @handle_csharp_exceptions
+    def find_text(self, text: str, backward: bool, ignore_case: bool) -> Optional["TextRange"]:
+        """Find a sub-range containing the given text.
+
+        :param text: The text to find.
+        :param backward: Search backward from the end when ``True``.
+        :param ignore_case: Match case-insensitively when ``True``.
+        :return: The matching :class:`TextRange`, or ``None`` if not found.
+        """
+        result = self.raw_text_range.FindText(text, backward, ignore_case)
+        return None if result is None else TextRange(raw_text_range=result)
+
+    @handle_csharp_exceptions
+    def get_attribute_value(self, attribute: Any) -> Any:
+        """Return the value of a text attribute over the range.
+
+        :param attribute: The C# ``TextAttributeId`` to read.
+        :return: The attribute value (a mixed value if the attribute varies over the range).
+        """
+        return self.raw_text_range.GetAttributeValue(attribute)
+
+    @handle_csharp_exceptions
+    def get_bounding_rectangles(self) -> List[Rectangle]:
+        """Return the bounding rectangles of the text in the range.
+
+        :return: A list of :class:`Rectangle` for each line in the range.
+        """
+        return [Rectangle(raw_value=_) for _ in self.raw_text_range.GetBoundingRectangles()]
+
+    @handle_csharp_exceptions
+    def get_children(self) -> List[Any]:
+        """Return the embedded child elements within the range.
+
+        :return: A list of child automation elements.
+        """
+        from flaui.core.automation_elements import AutomationElement
+
+        return [AutomationElement(raw_element=_) for _ in self.raw_text_range.GetChildren()]
+
+    @handle_csharp_exceptions
+    def get_enclosing_element(self) -> Any:
+        """Return the innermost element that encloses the range.
+
+        :return: The enclosing :class:`~flaui.core.automation_elements.AutomationElement`.
+        """
+        from flaui.core.automation_elements import AutomationElement
+
+        return AutomationElement(raw_element=self.raw_text_range.GetEnclosingElement())
+
+    @handle_csharp_exceptions
+    def get_text(self, max_length: int = -1) -> str:
+        """Return the plain text of the range.
+
+        :param max_length: Maximum number of characters to return, or ``-1`` for all.
+        :return: The text of the range.
+        """
+        return self.raw_text_range.GetText(max_length)
+
+    @handle_csharp_exceptions
+    def move(self, unit: TextUnit, count: int) -> int:
+        """Move the range by the given number of text units.
+
+        :param unit: The unit to move by.
+        :param count: The number of units to move (negative moves backward).
+        :return: The number of units actually moved.
+        """
+        return self.raw_text_range.Move(unit.value, count)
+
+    @handle_csharp_exceptions
+    def move_endpoint_by_range(
+        self,
+        src_endpoint: TextPatternRangeEndpoint,
+        target_range: "TextRange",
+        target_endpoint: TextPatternRangeEndpoint,
+    ) -> None:
+        """Move an endpoint of this range to an endpoint of another range.
+
+        :param src_endpoint: The endpoint of this range to move.
+        :param target_range: The range whose endpoint becomes the new position.
+        :param target_endpoint: The endpoint of the target range to move to.
+        """
+        self.raw_text_range.MoveEndpointByRange(src_endpoint.value, target_range.raw_text_range, target_endpoint.value)
+
+    @handle_csharp_exceptions
+    def move_endpoint_by_unit(self, endpoint: TextPatternRangeEndpoint, unit: TextUnit, count: int) -> int:
+        """Move an endpoint of the range by the given number of text units.
+
+        :param endpoint: The endpoint to move.
+        :param unit: The unit to move by.
+        :param count: The number of units to move (negative moves backward).
+        :return: The number of units actually moved.
+        """
+        return self.raw_text_range.MoveEndpointByUnit(endpoint.value, unit.value, count)
+
+    @handle_csharp_exceptions
+    def remove_from_selection(self) -> None:
+        """Remove the text range from the current selection."""
+        self.raw_text_range.RemoveFromSelection()
+
+    @handle_csharp_exceptions
+    def scroll_into_view(self, align_to_top: bool) -> None:
+        """Scroll the range into view.
+
+        :param align_to_top: Align the range to the top of the viewport when ``True``.
+        """
+        self.raw_text_range.ScrollIntoView(align_to_top)
+
+    @handle_csharp_exceptions
+    def select(self) -> None:
+        """Select the text range, replacing any existing selection."""
+        self.raw_text_range.Select()

--- a/tests/ui/core/automation_elements/test_textbox.py
+++ b/tests/ui/core/automation_elements/test_textbox.py
@@ -48,9 +48,8 @@ class TestTextbox:
         if test_application_type == "WinForms":
             pytest.skip("WinForms currently does not report the color on text boxes")
 
-        # Text pattern is not yet wrapped; reach the native pattern via the raw escape hatch.
-        text_range = textbox.patterns.raw_patterns.Text.Pattern
-        color_int = text_range.DocumentRange.GetAttributeValue(
+        text_pattern = textbox.patterns.text.pattern
+        color_int = text_pattern.document_range.get_attribute_value(
             test_application.main_window.automation.text_attribute_library.ForegroundColor
         )
         color = Color.from_argb(color_int)

--- a/tests/unit/core/test_patterns_family3.py
+++ b/tests/unit/core/test_patterns_family3.py
@@ -1,0 +1,252 @@
+"""Unit tests for the Text/Window/Transform/Dock pattern family (``flaui.core.patterns``).
+
+These exercise the wrapper plumbing with lightweight fakes (a ``SimpleNamespace`` stands in for the
+native C# objects), so they need no running UI. The Text pattern is additionally covered end-to-end
+by the textbox color UI test, which reads a document-range attribute through the new facade.
+"""
+
+from types import SimpleNamespace
+
+from flaui.core.automation_elements import AutomationProperty
+from flaui.core.definitions import (
+    DockPosition,
+    SupportedTextSelection,
+    TextPatternRangeEndpoint,
+    TextUnit,
+    WindowVisualState,
+    ZoomUnit,
+)
+from flaui.core.patterns import (
+    DockPattern,
+    Patterns,
+    Text2Pattern,
+    TextChildPattern,
+    TextEditPattern,
+    TextPattern,
+    Transform2Pattern,
+    TransformPattern,
+    WindowPattern,
+)
+from flaui.core.text_range import TextRange
+
+
+def _prop(value: object) -> SimpleNamespace:
+    """Build a fake native ``AutomationProperty`` whose ``Value`` is ``value``."""
+    return SimpleNamespace(Value=value)
+
+
+class TestTextRange:
+    """Validate the TextRange wrapper."""
+
+    def test_clone_wraps_result(self) -> None:
+        """``clone`` wraps the native clone in a :class:`TextRange`."""
+        inner = SimpleNamespace()
+        native = SimpleNamespace(Clone=lambda: inner)
+        cloned = TextRange(raw_text_range=native).clone()
+        assert isinstance(cloned, TextRange)
+        assert cloned.raw_text_range is inner
+
+    def test_get_text_delegates(self) -> None:
+        """``get_text`` forwards the max-length argument and returns the text."""
+        captured = {}
+        native = SimpleNamespace(GetText=lambda n: (captured.update(n=n), "hello")[1])
+        assert TextRange(raw_text_range=native).get_text(5) == "hello"
+        assert captured["n"] == 5
+
+    def test_enum_conversion_at_boundary(self) -> None:
+        """Text-unit / endpoint enums are converted to their C# values at the boundary."""
+        captured = {}
+        native = SimpleNamespace(
+            ExpandToEnclosingUnit=lambda u: captured.setdefault("unit", u),
+            Move=lambda u, c: captured.update(move_unit=u, count=c) or c,
+        )
+        rng = TextRange(raw_text_range=native)
+        rng.expand_to_enclosing_unit(TextUnit.Word)
+        assert captured["unit"] == TextUnit.Word.value
+        assert rng.move(TextUnit.Character, 3) == 3
+        assert captured["move_unit"] == TextUnit.Character.value
+
+    def test_find_text_none_returns_none(self) -> None:
+        """``find_text`` returns ``None`` when the native call finds nothing."""
+        native = SimpleNamespace(FindText=lambda t, b, i: None)
+        assert TextRange(raw_text_range=native).find_text("x", False, True) is None
+
+    def test_compare_endpoints_passes_raw(self) -> None:
+        """``compare_endpoints`` unwraps the target range and converts the endpoints."""
+        captured = {}
+        target_native = SimpleNamespace()
+        native = SimpleNamespace(
+            CompareEndpoints=lambda s, t, e: captured.update(s=s, t=t, e=e) or 0,
+        )
+        target = TextRange(raw_text_range=target_native)
+        result = TextRange(raw_text_range=native).compare_endpoints(
+            TextPatternRangeEndpoint.Start, target, TextPatternRangeEndpoint.End
+        )
+        assert result == 0
+        assert captured["s"] == TextPatternRangeEndpoint.Start.value
+        assert captured["t"] is target_native
+        assert captured["e"] == TextPatternRangeEndpoint.End.value
+
+
+class TestTextPatterns:
+    """Validate the Text, Text2, TextEdit, and TextChild pattern wrappers."""
+
+    def test_text_pattern_surface(self) -> None:
+        """TextPattern exposes the document range, selection mode, and range collections."""
+        doc = SimpleNamespace()
+        native = SimpleNamespace(
+            DocumentRange=doc,
+            SupportedTextSelection=SupportedTextSelection.Single.value,
+            GetSelection=lambda: [SimpleNamespace(), SimpleNamespace()],
+        )
+        pattern = TextPattern(raw_pattern=native)
+        assert isinstance(pattern.document_range, TextRange)
+        assert pattern.document_range.raw_text_range is doc
+        assert pattern.supported_text_selection == SupportedTextSelection.Single
+        ranges = pattern.get_selection()
+        assert len(ranges) == 2
+        assert all(isinstance(r, TextRange) for r in ranges)
+
+    def test_text2_extends_text_and_returns_caret_tuple(self) -> None:
+        """Text2 inherits Text and returns the caret range plus its active flag."""
+        caret = SimpleNamespace()
+        native = SimpleNamespace(GetCaretRange=lambda: (caret, True))
+        pattern = Text2Pattern(raw_pattern=native)
+        assert isinstance(pattern, TextPattern)
+        caret_range, is_active = pattern.get_caret_range()
+        assert isinstance(caret_range, TextRange)
+        assert caret_range.raw_text_range is caret
+        assert is_active is True
+
+    def test_text_edit_handles_missing_composition(self) -> None:
+        """TextEdit returns ``None`` when there is no active composition."""
+        native = SimpleNamespace(GetActiveComposition=lambda: None, GetConversionTarget=lambda: SimpleNamespace())
+        pattern = TextEditPattern(raw_pattern=native)
+        assert isinstance(pattern, TextPattern)
+        assert pattern.get_active_composition() is None
+        assert isinstance(pattern.get_conversion_target(), TextRange)
+
+    def test_text_child_surface(self) -> None:
+        """TextChild exposes its container element and enclosing text range."""
+        native = SimpleNamespace(TextContainer=SimpleNamespace(), TextRange=SimpleNamespace())
+        pattern = TextChildPattern(raw_pattern=native)
+        assert pattern.text_container is not None
+        assert isinstance(pattern.text_range, TextRange)
+
+
+class TestWindowPattern:
+    """Validate the Window pattern wrapper."""
+
+    def test_properties_and_methods(self) -> None:
+        """Window properties surface as AutomationProperty; methods convert/forward."""
+        captured = {}
+        native = SimpleNamespace(
+            CanMaximize=_prop(True),
+            CanMinimize=_prop(False),
+            IsModal=_prop(False),
+            IsTopmost=_prop(True),
+            WindowInteractionState=_prop("Running"),
+            WindowVisualState=_prop("Normal"),
+            Close=lambda: captured.setdefault("closed", True),
+            SetWindowVisualState=lambda s: captured.setdefault("state", s),
+            WaitForInputIdle=lambda ms: (captured.update(ms=ms), True)[1],
+        )
+        pattern = WindowPattern(raw_pattern=native)
+        assert isinstance(pattern.can_maximize, AutomationProperty)
+        assert pattern.can_maximize.value is True
+        assert pattern.is_topmost.value is True
+        pattern.close()
+        pattern.set_window_visual_state(WindowVisualState.Maximized)
+        assert pattern.wait_for_input_idle(100) is True
+        assert captured["closed"] is True
+        assert captured["state"] == WindowVisualState.Maximized.value
+        assert captured["ms"] == 100
+
+
+class TestTransformPatterns:
+    """Validate the Transform and Transform2 pattern wrappers."""
+
+    def test_transform_methods(self) -> None:
+        """Transform forwards move/resize/rotate to the native pattern."""
+        captured = {}
+        native = SimpleNamespace(
+            CanMove=_prop(True),
+            CanResize=_prop(True),
+            CanRotate=_prop(False),
+            Move=lambda x, y: captured.update(move=(x, y)),
+            Resize=lambda w, h: captured.update(resize=(w, h)),
+            Rotate=lambda d: captured.update(rotate=d),
+        )
+        pattern = TransformPattern(raw_pattern=native)
+        assert pattern.can_move.value is True
+        pattern.move(1.0, 2.0)
+        pattern.resize(30.0, 40.0)
+        pattern.rotate(90.0)
+        assert captured == {"move": (1.0, 2.0), "resize": (30.0, 40.0), "rotate": 90.0}
+
+    def test_transform2_extends_transform_and_converts_zoom_unit(self) -> None:
+        """Transform2 inherits Transform and converts the ZoomUnit at the boundary."""
+        captured = {}
+        native = SimpleNamespace(
+            CanMove=_prop(True),
+            CanResize=_prop(True),
+            CanRotate=_prop(True),
+            CanZoom=_prop(True),
+            ZoomLevel=_prop(1.0),
+            ZoomMaximum=_prop(4.0),
+            ZoomMinimum=_prop(0.5),
+            Zoom=lambda z: captured.update(zoom=z),
+            ZoomByUnit=lambda u: captured.update(unit=u),
+        )
+        pattern = Transform2Pattern(raw_pattern=native)
+        assert isinstance(pattern, TransformPattern)
+        assert pattern.can_zoom.value is True
+        assert pattern.zoom_maximum.value == 4.0
+        pattern.zoom(2.0)
+        pattern.zoom_by_unit(ZoomUnit.SmallIncrement)
+        assert captured["zoom"] == 2.0
+        assert captured["unit"] == ZoomUnit.SmallIncrement.value
+
+
+class TestDockPattern:
+    """Validate the Dock pattern wrapper."""
+
+    def test_dock_position_and_set(self) -> None:
+        """Dock exposes the position property and converts the enum on set."""
+        captured = {}
+        native = SimpleNamespace(
+            DockPosition=_prop("Top"),
+            SetDockPosition=lambda p: captured.setdefault("pos", p),
+        )
+        pattern = DockPattern(raw_pattern=native)
+        assert isinstance(pattern.dock_position, AutomationProperty)
+        pattern.set_dock_position(DockPosition.Left)
+        assert captured["pos"] == DockPosition.Left.value
+
+
+class TestFacadeAccessors:
+    """Validate the new accessors on the ``Patterns`` facade."""
+
+    def test_facade_wires_family3_accessors(self) -> None:
+        """Each new facade accessor returns an accessor wired to the right pattern type."""
+        raw_patterns = SimpleNamespace(
+            Text=SimpleNamespace(IsSupported=True),
+            Text2=SimpleNamespace(IsSupported=True),
+            TextEdit=SimpleNamespace(IsSupported=False),
+            TextChild=SimpleNamespace(IsSupported=False),
+            Window=SimpleNamespace(IsSupported=True),
+            Transform=SimpleNamespace(IsSupported=True),
+            Transform2=SimpleNamespace(IsSupported=False),
+            Dock=SimpleNamespace(IsSupported=False),
+        )
+        facade = Patterns(raw_patterns=raw_patterns)
+        assert facade.text.pattern_type is TextPattern
+        assert facade.text2.pattern_type is Text2Pattern
+        assert facade.text_edit.pattern_type is TextEditPattern
+        assert facade.text_child.pattern_type is TextChildPattern
+        assert facade.window.pattern_type is WindowPattern
+        assert facade.transform.pattern_type is TransformPattern
+        assert facade.transform2.pattern_type is Transform2Pattern
+        assert facade.dock.pattern_type is DockPattern
+        assert facade.text.is_supported is True
+        assert facade.dock.is_supported is False


### PR DESCRIPTION
## Summary
Third incremental pattern family for Phase 2 (#91), **stacked on #115**.

- **Text family** — `TextPattern`, `Text2Pattern`, `TextEditPattern`, `TextChildPattern`, backed by a new **`TextRange`** wrapper (`flaui/core/text_range.py`) mirroring C# `ITextRange` (all 18 members).
- **WindowPattern** — can-maximize/minimize, modal, topmost, interaction/visual state; `close()`, `set_window_visual_state()`, `wait_for_input_idle()`.
- **TransformPattern** / **Transform2Pattern** — move/resize/rotate + zoom.
- **DockPattern** — `dock_position` + `set_dock_position()`.

Adds 7 enums to `definitions.py` mirroring `FlaUI.Core.Definitions`: `WindowVisualState`, `WindowInteractionState`, `DockPosition`, `ZoomUnit`, `SupportedTextSelection`, `TextPatternRangeEndpoint`, `TextUnit` (converted at the C# boundary).

All 8 accessors wired into the `Patterns` facade.

## Tests / docs
- The **textbox color UI test** now reads its document-range attribute through the wrapped Text pattern (dropping the raw escape hatch added in #114) — real end-to-end coverage of `TextPattern` + `TextRange`.
- **14 new unit tests** cover wiring, enum conversion, tuple/None returns, and method delegation with fakes.
- `docs/api/patterns.md` documents `TextRange`.

## Verification
- `ruff` clean, `interrogate` 100%
- 14 unit + textbox UI test pass; strict Zensical build green

> Stacked on #115 → #114. Merge those first; will rebase onto master as they land.

Part of #91.