### PR TITLE
docs: reflect hybrid Azure Pipelines + AppVeyor CI in instruction files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Step-by-step / procedural guides live in `docs/` and are linked from CLAUDE.md's
 
 - Pytest matrix configuration & writing matrix tests — [docs/contributing/testing.md](docs/contributing/testing.md)
 - Test porting methodology from FlaUI C# — [docs/contributing/porting-tests.md](docs/contributing/porting-tests.md)
-- Development workflow (UV), code quality, CI/CD — [docs/contributing/development.md](docs/contributing/development.md)
+- Development workflow (UV), code quality, CI/CD (hybrid Azure Pipelines + AppVeyor) — [docs/contributing/development.md](docs/contributing/development.md)
 - Bug tracking with pytest-bug — [docs/bug-tracking.md](docs/bug-tracking.md)
 - Troubleshooting and known skips/xfails — [docs/troubleshooting.md](docs/troubleshooting.md)
 
@@ -96,6 +96,9 @@ When working on this project:
 - ⚠️ **Always** add type hints to test fixtures
 - ⚠️ **Always** use fixture parametrization for matrix, not `@pytest.parametrize`
 - ⚠️ **Always** convert C# exceptions with `@handle_csharp_exceptions`
+- ⚠️ **CI is hybrid**: Azure Pipelines (`azure-pipelines.yml`, check `flaui-uiautomation-wrapper-ci`)
+  gates linting/docs/smoke/packaging; AppVeyor (`.appveyor.yml`) runs the full Windows UI suite. A
+  PR with merge conflicts fails AppVeyor as "non-mergeable" — rebase/merge the base to clear it.
 
 ## Quick Links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ guides live in `docs/` (see [Where to find the tutorials](#where-to-find-the-tut
 - [Python Compatibility & Library Preferences](#python-compatibility--library-preferences)
 - [Coding Standards](#coding-standards)
 - [Key Files Reference](#key-files-reference)
+- [Continuous Integration](#continuous-integration)
 - [Documentation Standards](#documentation-standards)
 - [Where to find the tutorials](#where-to-find-the-tutorials)
 
@@ -480,6 +481,30 @@ assert element.toggle_state == ToggleState.On
 
 ---
 
+## Continuous Integration
+
+CI/CD runs on a **hybrid Azure Pipelines + AppVeyor** setup. The two systems split responsibilities:
+
+- **Azure Pipelines** ([`azure-pipelines.yml`](azure-pipelines.yml), GitHub check
+  `flaui-uiautomation-wrapper-ci`) owns the fast gates and release plumbing: Ruff + Interrogate
+  linting, the strict Zensical docs build, a hosted `windows-2022` smoke suite (unit + identifier
+  tests), package builds, and gated `deploy_testpypi` / `deploy_pypi` / `deploy_docs` stages.
+- **AppVeyor** ([`.appveyor.yml`](.appveyor.yml), checks `continuous-integration/appveyor/pr`
+  and `/branch`) is the hosted Windows desktop UI gate that runs the **full** FlaUI test suite on
+  `Visual Studio 2022`.
+- **GitHub Actions** is kept for CodeQL/labeling only; other workflows are manual-only stubs.
+
+Both runners drive tests with `uv run … pytest` and currently pin Python 3.12 x64 while the hybrid
+setup stabilizes (the 3.10–3.14 matrix is commented in both files). Azure cancels stale PR runs via
+`pr.autoCancel: true`; AppVeyor relies on the project-level **Rolling builds** setting (not a yaml
+key). A conflicting/non-mergeable PR makes AppVeyor report "unable to build non-mergeable pull
+request" — rebase or merge the base branch to clear it.
+
+Full procedural detail (scripts, artifacts, caching, deployment variables) lives in
+[docs/contributing/development.md](docs/contributing/development.md#cicd-azure-pipelines--appveyor).
+
+---
+
 ## Documentation Standards
 
 - Use Sphinx-style docstrings (one-line summary, then `:param:`, `:return:`, `:raises:`).
@@ -509,7 +534,7 @@ Procedural and step-by-step content has been relocated to the docs site:
 |-------|----------|
 | Pytest matrix configuration, writing matrix tests, `post_wait`, assertions | [docs/contributing/testing.md](docs/contributing/testing.md) |
 | Porting C# tests step by step, element maps | [docs/contributing/porting-tests.md](docs/contributing/porting-tests.md) |
-| UV commands, code quality, pre-commit, exception handling, CI/CD, docs build | [docs/contributing/development.md](docs/contributing/development.md) |
+| UV commands, code quality, pre-commit, exception handling, CI/CD (Azure Pipelines + AppVeyor), docs build | [docs/contributing/development.md](docs/contributing/development.md) |
 | pytest-bug usage and current bug markers | [docs/bug-tracking.md](docs/bug-tracking.md) |
 | Common issues, fixes, known skips/xfails | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | Contributor overview | [docs/contributing.md](docs/contributing.md) |


### PR DESCRIPTION
## Summary
The repo moved to a hybrid **Azure Pipelines + AppVeyor** CI. This updates the agent instruction files so they reflect that setup (the detailed procedural docs already live in `docs/contributing/development.md`).

- **CLAUDE.md**: new durable *Continuous Integration* section (+ TOC entry) naming both systems and their responsibility split (Azure = lint/docs/smoke/packaging/deploy; AppVeyor = full Windows UI suite; GitHub Actions = CodeQL/labels). Tutorials table row clarified.
- **AGENTS.md**: CI/CD reference now names the hybrid setup; added a reminder that a conflicting PR fails AppVeyor as "non-mergeable".

## Notes
Documentation-only change. No code or pipeline behavior touched.
