### PR TITLE
test(patterns): UI integration tests for all pattern families + trim CI gate (GH-91)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,6 @@
-# AppVeyor remains the hosted Windows desktop UI gate for the full FlaUI suite.
+# AppVeyor is the hosted Windows desktop UI gate for the FlaUI suite. The gate is
+# trimmed (see test_script): the full UI suite runs only on pull requests and on
+# master; routine feature-branch pushes run the fast tests/unit subset instead.
 # Azure Pipelines owns linting, docs, packaging, deployment plumbing, and a
 # smaller hosted Windows smoke job.
 # Enable AppVeyor "Rolling builds" in project settings for pull requests so
@@ -75,8 +77,18 @@ test_script:
       $env:UV_PROJECT_ENVIRONMENT = "$env:APPVEYOR_BUILD_FOLDER\.venv"
       $env:UV_CACHE_DIR = "$env:USERPROFILE\.cache\uv"
       $env:UV_NO_PROGRESS = "1"
-      Write-Host "Running full Windows desktop UI test suite with pytest..."
-      Invoke-Checked { uv --no-progress run --group unit-test --no-dev --package flaui-uiautomation-wrapper --extra coverage coverage run -m pytest --junit-xml=test-results.xml --timeout=45 --timeout-method=thread --alluredir allure-results }
+
+      # Trim the gate: the slow full desktop UI suite only runs where it gates a merge
+      # (pull requests, and pushes to master). Routine feature-branch pushes run the fast
+      # unit subset only, so day-to-day turnaround does not pay for the full serial run.
+      $runFull = ($env:APPVEYOR_REPO_BRANCH -eq 'master') -or [bool]$env:APPVEYOR_PULL_REQUEST_NUMBER
+      if ($runFull) {
+        Write-Host "Full gate: running the complete Windows desktop UI test suite with pytest..."
+        Invoke-Checked { uv --no-progress run --group unit-test --no-dev --package flaui-uiautomation-wrapper --extra coverage coverage run -m pytest --junit-xml=test-results.xml --timeout=45 --timeout-method=thread --alluredir allure-results }
+      } else {
+        Write-Host "Fast gate: running the unit subset only (the full UI suite runs on pull requests and on master)..."
+        Invoke-Checked { uv --no-progress run --group unit-test --no-dev --package flaui-uiautomation-wrapper --extra coverage coverage run -m pytest tests/unit --junit-xml=test-results.xml --timeout=45 --timeout-method=thread --alluredir allure-results }
+      }
 
 after_test:
   - ps: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,10 @@ When working on this project:
 - ⚠️ **Always** use fixture parametrization for matrix, not `@pytest.parametrize`
 - ⚠️ **Always** convert C# exceptions with `@handle_csharp_exceptions`
 - ⚠️ **CI is hybrid**: Azure Pipelines (`azure-pipelines.yml`, check `flaui-uiautomation-wrapper-ci`)
-  gates linting/docs/smoke/packaging; AppVeyor (`.appveyor.yml`) runs the full Windows UI suite. A
-  PR with merge conflicts fails AppVeyor as "non-mergeable" — rebase/merge the base to clear it.
+  gates linting/docs/smoke/packaging; AppVeyor (`.appveyor.yml`) is the Windows UI gate. AppVeyor is
+  **trimmed**: the full UI suite runs only on pull requests and on `master`; routine feature-branch
+  pushes run the fast `tests/unit` subset. A PR with merge conflicts fails AppVeyor as
+  "non-mergeable" — rebase/merge the base to clear it.
 
 ## Quick Links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,8 +490,11 @@ CI/CD runs on a **hybrid Azure Pipelines + AppVeyor** setup. The two systems spl
   linting, the strict Zensical docs build, a hosted `windows-2022` smoke suite (unit + identifier
   tests), package builds, and gated `deploy_testpypi` / `deploy_pypi` / `deploy_docs` stages.
 - **AppVeyor** ([`.appveyor.yml`](.appveyor.yml), checks `continuous-integration/appveyor/pr`
-  and `/branch`) is the hosted Windows desktop UI gate that runs the **full** FlaUI test suite on
-  `Visual Studio 2022`.
+  and `/branch`) is the hosted Windows desktop UI gate on `Visual Studio 2022`. The gate is
+  **trimmed**: the slow full UI suite only runs where it gates a merge — **pull requests and pushes
+  to `master`** (`APPVEYOR_PULL_REQUEST_NUMBER` set, or `APPVEYOR_REPO_BRANCH == master`). Routine
+  feature-branch pushes run the **fast `tests/unit` subset only**, so day-to-day turnaround does not
+  pay for the full serial run.
 - **GitHub Actions** is kept for CodeQL/labeling only; other workflows are manual-only stubs.
 
 Both runners drive tests with `uv run … pytest` and currently pin Python 3.12 x64 while the hybrid

--- a/docs/api/patterns.md
+++ b/docs/api/patterns.md
@@ -15,6 +15,14 @@ element.patterns.toggle.is_supported
 Each pattern wraps a native C# pattern object, always reachable via `raw_pattern` as an escape
 hatch for members that are not yet wrapped. Patterns are ported incrementally by family.
 
+!!! note "Pattern parity"
+    The wrapper covers **all 34 patterns** that FlaUI exposes through
+    `FrameworkAutomationElementBase.IFrameworkPatterns` — full parity with the FlaUI C# API.
+    The Microsoft UIA `CustomNavigation` pattern is intentionally **not** included: FlaUI itself
+    does not surface it (it lives only in the underlying `Interop.UIAutomationClient` COM layer), so
+    wrapping it would break the 1:1-with-FlaUI mapping. It is tracked as a post-v1 wishlist item in
+    [GH-121](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/121).
+
 ::: flaui.core.patterns
 
 ## Text ranges

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -91,9 +91,11 @@ The project uses a hybrid CI setup:
 
 - Azure Pipelines (`azure-pipelines.yml`) owns linting, documentation, packaging, deployment
   plumbing, and a hosted Windows smoke suite.
-- AppVeyor (`.appveyor.yml`) remains the hosted Windows desktop UI gate for the full FlaUI test
-  suite. Paint-specific XPath cases that can abort native UIA/COM on hosted CI are skipped there
-  and remain runnable locally.
+- AppVeyor (`.appveyor.yml`) is the hosted Windows desktop UI gate. The gate is **trimmed**: the
+  slow full FlaUI UI suite only runs where it gates a merge — pull requests and pushes to `master`
+  (`APPVEYOR_PULL_REQUEST_NUMBER` set, or `APPVEYOR_REPO_BRANCH == master`). Routine feature-branch
+  pushes run the fast `tests/unit` subset only. Paint-specific XPath cases that can abort native
+  UIA/COM on hosted CI are skipped there and remain runnable locally.
 - GitHub Actions workflows are retained as manual-only stubs while CI/CD ownership moves to Azure
   and AppVeyor.
 
@@ -103,7 +105,9 @@ Azure currently runs three PR validation jobs in parallel:
 - Strict documentation build
 - Windows hosted smoke tests on Microsoft-hosted `windows-2022`
 
-AppVeyor runs the full Windows desktop UI suite on `Visual Studio 2022`.
+AppVeyor runs on `Visual Studio 2022`. It runs the full Windows desktop UI suite on pull requests
+and on `master`, and the fast `tests/unit` subset on routine feature-branch pushes (the gate is
+selected in `test_script` from `APPVEYOR_PULL_REQUEST_NUMBER` / `APPVEYOR_REPO_BRANCH`).
 
 ### Stale build cancellation
 
@@ -125,13 +129,21 @@ when a newer commit is pushed.
       --junit-xml=test-results.xml --alluredir allure-results
 ```
 
-### AppVeyor full UI script
+### AppVeyor test script (trimmed gate)
 
 ```yaml
 - ps: |
-    uv run --group unit-test --no-dev --package flaui-uiautomation-wrapper --extra coverage \
-      coverage run -m pytest --timeout=45 --timeout-method=thread \
-      --junit-xml=test-results.xml --alluredir allure-results
+    # Full UI suite only where it gates a merge; fast unit subset otherwise.
+    $runFull = ($env:APPVEYOR_REPO_BRANCH -eq 'master') -or [bool]$env:APPVEYOR_PULL_REQUEST_NUMBER
+    if ($runFull) {
+      uv run --group unit-test --no-dev --package flaui-uiautomation-wrapper --extra coverage \
+        coverage run -m pytest --timeout=45 --timeout-method=thread \
+        --junit-xml=test-results.xml --alluredir allure-results
+    } else {
+      uv run --group unit-test --no-dev --package flaui-uiautomation-wrapper --extra coverage \
+        coverage run -m pytest tests/unit --timeout=45 --timeout-method=thread \
+        --junit-xml=test-results.xml --alluredir allure-results
+    }
 ```
 
 Key parameters:

--- a/flaui/core/patterns/patterns.py
+++ b/flaui/core/patterns/patterns.py
@@ -9,6 +9,11 @@ one-to-one::
 
 The underlying C# ``IFrameworkPatterns`` object remains reachable via :attr:`Patterns.raw_patterns`
 as an escape hatch for patterns that are not yet wrapped.
+
+This facade exposes all 34 patterns that FlaUI surfaces through ``IFrameworkPatterns`` (full parity
+with the FlaUI C# API). The Microsoft UIA ``CustomNavigation`` pattern is intentionally excluded:
+FlaUI does not expose it (it exists only in the ``Interop.UIAutomationClient`` COM layer), so adding
+it would break the 1:1-with-FlaUI mapping. It is tracked as a post-v1 wishlist item (GH-121).
 """
 
 from __future__ import annotations

--- a/tests/ui/core/patterns/conftest.py
+++ b/tests/ui/core/patterns/conftest.py
@@ -1,0 +1,34 @@
+"""Shared fixtures for pattern UI integration tests."""
+
+from typing import Any, Callable
+
+import pytest
+
+
+@pytest.fixture
+def is_pattern_supported() -> Callable[[Any, str], bool]:
+    """Return a helper that reports whether ``patterns.<name>`` is supported.
+
+    Some patterns are absent from a UIA framework entirely (notably several patterns under UIA2).
+    FlaUI surfaces that by raising ``NotSupportedByFrameworkException`` when the accessor is first
+    materialised, rather than reporting ``is_supported == False``. The returned helper treats that
+    case as "not supported" so tests can guard uniformly across the UIA2/UIA3 matrix.
+
+    :return: A callable ``(patterns, name) -> bool``.
+    """
+
+    def _is_supported(patterns: Any, name: str) -> bool:
+        """Check pattern support, treating framework-unsupported patterns as unsupported.
+
+        :param patterns: The element's ``patterns`` facade.
+        :param name: The snake_case pattern accessor name (e.g. ``"styles"``).
+        :return: ``True`` if the pattern is supported, else ``False``.
+        """
+        from FlaUI.Core.Exceptions import NotSupportedByFrameworkException
+
+        try:
+            return bool(getattr(patterns, name).is_supported)
+        except NotSupportedByFrameworkException:
+            return False
+
+    return _is_supported

--- a/tests/ui/core/patterns/test_item_container_pattern.py
+++ b/tests/ui/core/patterns/test_item_container_pattern.py
@@ -1,0 +1,36 @@
+"""UI integration test for the ItemContainer pattern on a ListBox control (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestItemContainerPattern:
+    """Tests for the ItemContainer pattern on a ListBox control."""
+
+    @pytest.fixture(name="list_box")
+    def get_list_box(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the ListBox element.
+
+        :param test_application: Test application elements.
+        :yield: ListBox automation element.
+        """
+        yield test_application.simple_controls_tab.list_box
+
+    def test_item_container_pattern(self, list_box: AutomationElement, is_pattern_supported: object) -> None:
+        """Find the first contained item through the ItemContainer pattern when supported."""
+        assert_that(list_box, not_none())
+        if not is_pattern_supported(list_box.patterns, "item_container"):  # type: ignore[operator]
+            pytest.skip("ItemContainer pattern is not supported on this control/runtime")
+        # ``find_item_by_property(None, None, None)`` returns the first contained item.
+        first_item = list_box.patterns.item_container.pattern.find_item_by_property(None, None, None)
+        assert_that(first_item, not_none())

--- a/tests/ui/core/patterns/test_legacy_i_accessible_pattern.py
+++ b/tests/ui/core/patterns/test_legacy_i_accessible_pattern.py
@@ -1,0 +1,41 @@
+"""UI integration test for the LegacyIAccessible pattern on a Button control (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestLegacyIAccessiblePattern:
+    """Tests for the LegacyIAccessible (MSAA bridge) pattern on a standard control."""
+
+    @pytest.fixture(name="element")
+    def get_element(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get a control that resolves on both WinForms and WPF.
+
+        :param test_application: Test application elements.
+        :yield: CheckBox automation element.
+        """
+        yield test_application.simple_controls_tab.test_check_box
+
+    def test_legacy_i_accessible_pattern(
+        self,
+        element: AutomationElement,
+        is_pattern_supported: object,
+    ) -> None:
+        """Read MSAA name and role through the LegacyIAccessible pattern when supported."""
+        assert_that(element, not_none())
+        if not is_pattern_supported(element.patterns, "legacy_i_accessible"):  # type: ignore[operator]
+            pytest.skip("LegacyIAccessible pattern is not supported on this control/runtime")
+        legacy_pattern = element.patterns.legacy_i_accessible.pattern
+        name = legacy_pattern.name.value_or_default
+        assert name is None or isinstance(name, str)
+        assert legacy_pattern.role.value is not None

--- a/tests/ui/core/patterns/test_multiple_view_pattern.py
+++ b/tests/ui/core/patterns/test_multiple_view_pattern.py
@@ -1,0 +1,29 @@
+"""UI integration test for the MultipleView pattern (GH-91)."""
+
+from flaui.core.definitions import ControlType
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestMultipleViewPattern:
+    """Tests for the MultipleView pattern on a control that exposes several presentations."""
+
+    def test_multiple_view_pattern(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+        is_pattern_supported: object,
+    ) -> None:
+        """Read the current and supported views when the pattern is available, else skip."""
+        tab = test_application.main_window.find_first_descendant(
+            condition=test_application._cf.by_control_type(ControlType.Tab)
+        )
+        assert_that(tab, not_none())
+        if not is_pattern_supported(tab.patterns, "multiple_view"):  # type: ignore[operator]
+            pytest.skip("MultipleView pattern is not supported by the available controls")
+        view_pattern = tab.patterns.multiple_view.pattern
+        assert view_pattern.supported_views.value is not None
+        assert view_pattern.current_view.value is not None

--- a/tests/ui/core/patterns/test_scroll_pattern.py
+++ b/tests/ui/core/patterns/test_scroll_pattern.py
@@ -1,0 +1,41 @@
+"""UI integration test for the Scroll pattern on a scrollable list view (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestScrollPattern:
+    """Tests for the Scroll pattern on the LargeListView control."""
+
+    @pytest.fixture(name="large_list_view")
+    def get_large_list_view(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the LargeListView element from the Complex Controls tab.
+
+        :param test_application: Test application elements.
+        :yield: LargeListView automation element.
+        """
+        yield test_application.complex_controls_tab.large_list_view
+
+    def test_scroll_pattern(self, large_list_view: AutomationElement, is_pattern_supported: object) -> None:
+        """Scroll the content vertically and verify the scroll percentage moves, then reset it."""
+        assert_that(large_list_view, not_none())
+        if not is_pattern_supported(large_list_view.patterns, "scroll"):  # type: ignore[operator]
+            pytest.skip("Scroll pattern is not supported on this control/runtime")
+        scroll_pattern = large_list_view.patterns.scroll.pattern
+        if not scroll_pattern.vertically_scrollable.value:
+            pytest.skip("Content is not vertically scrollable")
+        try:
+            scroll_pattern.set_scroll_percent(-1, 50)
+            assert scroll_pattern.vertical_scroll_percent.value > 0
+        finally:
+            scroll_pattern.set_scroll_percent(-1, 0)

--- a/tests/ui/core/patterns/test_selection_pattern.py
+++ b/tests/ui/core/patterns/test_selection_pattern.py
@@ -1,0 +1,49 @@
+"""UI integration tests for the Selection and SelectionItem patterns on a ListBox (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.definitions import ControlType
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestSelectionPattern:
+    """Tests for the Selection and SelectionItem patterns on a ListBox control."""
+
+    @pytest.fixture(name="list_box")
+    def get_list_box(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the ListBox element.
+
+        :param test_application: Test application elements.
+        :yield: ListBox automation element.
+        """
+        yield test_application.simple_controls_tab.list_box
+
+    def test_selection_pattern(self, list_box: AutomationElement) -> None:
+        """Read the Selection pattern container flags."""
+        assert_that(list_box, not_none())
+        selection_pattern = list_box.patterns.selection.pattern
+        assert_that(selection_pattern, not_none())
+        assert isinstance(selection_pattern.can_select_multiple.value, bool)
+        assert isinstance(selection_pattern.is_selection_required.value, bool)
+
+    def test_selection_item_pattern(
+        self,
+        list_box: AutomationElement,
+        condition_factory: Any,
+    ) -> None:
+        """Select the first list item via the SelectionItem pattern and verify it is selected."""
+        items = list_box.find_all_descendants(condition=condition_factory.by_control_type(ControlType.ListItem))
+        assert len(items) > 0, "ListBox should expose at least one item"
+        selection_item_pattern = items[0].patterns.selection_item.pattern
+        assert_that(selection_item_pattern, not_none())
+        selection_item_pattern.select()
+        assert selection_item_pattern.is_selected.value is True

--- a/tests/ui/core/patterns/test_styles_pattern.py
+++ b/tests/ui/core/patterns/test_styles_pattern.py
@@ -1,0 +1,37 @@
+"""UI integration test for the Styles pattern on a DataGrid cell (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.wpf_only
+class TestStylesPattern:
+    """Tests for the Styles pattern on a WPF DataGrid cell."""
+
+    @pytest.fixture(name="data_grid")
+    def get_data_grid(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+        skip_on_winforms: None,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the DataGrid element from the Complex Controls tab.
+
+        :param test_application: Test application elements.
+        :param skip_on_winforms: Fixture that skips WinForms tests.
+        :yield: DataGrid automation element.
+        """
+        yield test_application.complex_controls_tab.data_grid_view
+
+    def test_styles_pattern(self, data_grid: AutomationElement, is_pattern_supported: object) -> None:
+        """Read the style identifier of a cell through the Styles pattern when supported."""
+        cell = data_grid.patterns.grid.pattern.get_item(1, 1)
+        assert_that(cell, not_none())
+        if not is_pattern_supported(cell.patterns, "styles"):  # type: ignore[operator]
+            pytest.skip("Styles pattern is not supported on this cell/runtime")
+        assert cell.patterns.styles.pattern.style.value is not None

--- a/tests/ui/core/patterns/test_table_pattern.py
+++ b/tests/ui/core/patterns/test_table_pattern.py
@@ -1,0 +1,57 @@
+"""UI integration tests for the Table, TableItem and GridItem patterns on a DataGrid (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.definitions import RowOrColumnMajor
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.wpf_only
+class TestTablePattern:
+    """Tests for the Table, TableItem and GridItem patterns on the WPF DataGrid control."""
+
+    @pytest.fixture(name="data_grid")
+    def get_data_grid(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+        skip_on_winforms: None,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the DataGrid element from the Complex Controls tab.
+
+        :param test_application: Test application elements.
+        :param skip_on_winforms: Fixture that skips WinForms tests.
+        :yield: DataGrid automation element.
+        """
+        yield test_application.complex_controls_tab.data_grid_view
+
+    def test_table_pattern(self, data_grid: AutomationElement, is_pattern_supported: object) -> None:
+        """Read the Table pattern row/column-major orientation."""
+        assert_that(data_grid, not_none())
+        if not is_pattern_supported(data_grid.patterns, "table"):  # type: ignore[operator]
+            pytest.skip("Table pattern is not supported on this DataGrid/runtime")
+        table_pattern = data_grid.patterns.table.pattern
+        assert table_pattern.row_or_column_major.value in (
+            RowOrColumnMajor.RowMajor.value,
+            RowOrColumnMajor.ColumnMajor.value,
+            RowOrColumnMajor.Indeterminate.value,
+        )
+
+    def test_grid_item_and_table_item_pattern(
+        self,
+        data_grid: AutomationElement,
+        is_pattern_supported: object,
+    ) -> None:
+        """Resolve a cell and read its GridItem coordinates and TableItem headers."""
+        cell = data_grid.patterns.grid.pattern.get_item(1, 1)
+        assert_that(cell, not_none())
+        grid_item_pattern = cell.patterns.grid_item.pattern
+        assert grid_item_pattern.row.value == 1
+        assert grid_item_pattern.column.value == 1
+        if is_pattern_supported(cell.patterns, "table_item"):  # type: ignore[operator]
+            # Accessing the header items should not raise; the value is an element collection.
+            assert cell.patterns.table_item.pattern.column_header_items is not None

--- a/tests/ui/core/patterns/test_text_pattern.py
+++ b/tests/ui/core/patterns/test_text_pattern.py
@@ -1,0 +1,57 @@
+"""UI integration tests for the Text and Text2 patterns on a TextBox control (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.definitions import SupportedTextSelection
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestTextPattern:
+    """Tests for the Text pattern (and the UIA3-only Text2 pattern) on a TextBox control."""
+
+    @pytest.fixture(name="text_box")
+    def get_text_box(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the editable TextBox element.
+
+        :param test_application: Test application elements.
+        :yield: TextBox automation element.
+        """
+        yield test_application.simple_controls_tab.test_text_box
+
+    def test_text_pattern(self, text_box: AutomationElement, is_pattern_supported: object) -> None:
+        """Read the document range text through the Text pattern, restoring the original content."""
+        assert_that(text_box, not_none())
+        if not is_pattern_supported(text_box.patterns, "text"):  # type: ignore[operator]
+            pytest.skip("Text pattern is not supported on this control/runtime")
+        text_pattern = text_box.patterns.text.pattern
+        assert isinstance(text_pattern.supported_text_selection, SupportedTextSelection)
+        value_pattern = text_box.patterns.value.pattern
+        original = value_pattern.value.value
+        try:
+            value_pattern.set_value("text pattern content")
+            assert "text pattern content" in text_pattern.document_range.get_text()
+        finally:
+            value_pattern.set_value(original or "")
+
+    def test_text2_pattern_plumbing(
+        self,
+        text_box: AutomationElement,
+        skip_on_uia2: None,
+        is_pattern_supported: object,
+    ) -> None:
+        """Verify the Text2 accessor (UIA3-only) resolves and reports support as a boolean.
+
+        :param text_box: TextBox automation element.
+        :param skip_on_uia2: Fixture that skips the test under UIA2.
+        :param is_pattern_supported: Helper that safely reports pattern support.
+        """
+        assert isinstance(is_pattern_supported(text_box.patterns, "text2"), bool)  # type: ignore[operator]

--- a/tests/ui/core/patterns/test_toggle_pattern.py
+++ b/tests/ui/core/patterns/test_toggle_pattern.py
@@ -1,0 +1,42 @@
+"""UI integration test for the Toggle pattern on a CheckBox control (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestTogglePattern:
+    """Tests for the Toggle pattern on a CheckBox control."""
+
+    @pytest.fixture(name="check_box")
+    def get_check_box(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the two-state CheckBox element.
+
+        :param test_application: Test application elements.
+        :yield: CheckBox automation element.
+        """
+        yield test_application.simple_controls_tab.test_check_box
+
+    def test_toggle_pattern(self, check_box: AutomationElement) -> None:
+        """Toggle the checkbox, verify the state flips, then restore the original state."""
+        assert_that(check_box, not_none())
+        toggle_pattern = check_box.patterns.toggle.pattern
+        assert_that(toggle_pattern, not_none())
+        original = toggle_pattern.toggle_state.value
+        try:
+            toggle_pattern.toggle()
+            assert toggle_pattern.toggle_state.value != original
+        finally:
+            # The test application is shared, so leave the checkbox as we found it.
+            if toggle_pattern.toggle_state.value != original:
+                toggle_pattern.toggle()
+            assert toggle_pattern.toggle_state.value == original

--- a/tests/ui/core/patterns/test_transform_pattern.py
+++ b/tests/ui/core/patterns/test_transform_pattern.py
@@ -1,0 +1,32 @@
+"""UI integration test for the Transform pattern (GH-91).
+
+The pattern is exercised read-only: the main window is shared across the session, so the test does
+not actually move or resize it (that would break sibling tests). It validates that the transform
+flags are readable when the pattern is supported.
+"""
+
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestTransformPattern:
+    """Tests for the Transform pattern flags on the application main window."""
+
+    def test_transform_pattern(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+        is_pattern_supported: object,
+    ) -> None:
+        """Read the Transform pattern capability flags without mutating the shared window."""
+        main_window = test_application.main_window
+        if not is_pattern_supported(main_window.patterns, "transform"):  # type: ignore[operator]
+            pytest.skip("Transform pattern is not supported on the main window for this runtime")
+        transform_pattern = main_window.patterns.transform.pattern
+        assert_that(transform_pattern, not_none())
+        assert isinstance(transform_pattern.can_move.value, bool)
+        assert isinstance(transform_pattern.can_resize.value, bool)
+        assert isinstance(transform_pattern.can_rotate.value, bool)

--- a/tests/ui/core/patterns/test_unsupported_patterns.py
+++ b/tests/ui/core/patterns/test_unsupported_patterns.py
@@ -1,0 +1,78 @@
+"""UI integration tests asserting the pattern facade reports unsupported patterns (GH-91).
+
+Several UIA patterns have no suitable control in the WinForms/WPF test applications (Dock,
+Annotation, Drag, DropTarget, ObjectModel, Spreadsheet, SpreadsheetItem, SynchronizedInput). Rather
+than fabricate coverage, these tests exercise the facade plumbing end-to-end by confirming that the
+``is_supported`` accessor resolves for each pattern on a plain control.
+"""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestUnsupportedPatterns:
+    """Facade plumbing tests for patterns with no exercisable control in the test apps."""
+
+    @pytest.fixture(name="element")
+    def get_element(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get a plain control that resolves on both WinForms and WPF.
+
+        :param test_application: Test application elements.
+        :yield: CheckBox automation element.
+        """
+        yield test_application.simple_controls_tab.test_check_box
+
+    @pytest.mark.parametrize(
+        "pattern_name",
+        [
+            "dock",
+            "annotation",
+            "drag",
+            "drop_target",
+            "object_model",
+            "spreadsheet",
+            "spreadsheet_item",
+        ],
+    )
+    def test_pattern_reports_unsupported(
+        self,
+        element: AutomationElement,
+        pattern_name: str,
+        is_pattern_supported: object,
+    ) -> None:
+        """A plain control should not support these specialised patterns on any UIA framework.
+
+        The helper treats both ``is_supported == False`` and a framework-level
+        ``NotSupportedByFrameworkException`` (raised under UIA2 for patterns absent from that
+        framework) as "not supported".
+
+        :param element: A standard control automation element.
+        :param pattern_name: Name of the pattern accessor on ``element.patterns``.
+        :param is_pattern_supported: Helper that safely reports pattern support.
+        """
+        assert_that(element, not_none())
+        assert is_pattern_supported(element.patterns, pattern_name) is False  # type: ignore[operator]
+
+    def test_synchronized_input_accessor_resolves(
+        self,
+        element: AutomationElement,
+        is_pattern_supported: object,
+    ) -> None:
+        """The SynchronizedInput accessor should resolve and report support as a boolean.
+
+        Support varies by control and runtime, so this only asserts the plumbing works.
+
+        :param element: A standard control automation element.
+        :param is_pattern_supported: Helper that safely reports pattern support.
+        """
+        assert isinstance(is_pattern_supported(element.patterns, "synchronized_input"), bool)  # type: ignore[operator]

--- a/tests/ui/core/patterns/test_value_pattern.py
+++ b/tests/ui/core/patterns/test_value_pattern.py
@@ -1,0 +1,40 @@
+"""UI integration test for the Value pattern on a TextBox control (GH-91)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestValuePattern:
+    """Tests for the Value pattern on a TextBox control."""
+
+    @pytest.fixture(name="text_box")
+    def get_text_box(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the editable TextBox element.
+
+        :param test_application: Test application elements.
+        :yield: TextBox automation element.
+        """
+        yield test_application.simple_controls_tab.test_text_box
+
+    def test_value_pattern(self, text_box: AutomationElement) -> None:
+        """Read and set the control value through the Value pattern, restoring the original text."""
+        assert_that(text_box, not_none())
+        value_pattern = text_box.patterns.value.pattern
+        assert_that(value_pattern, not_none())
+        assert value_pattern.is_read_only.value is False
+        original = value_pattern.value.value
+        try:
+            value_pattern.set_value("FlaUI value pattern")
+            assert value_pattern.value.value == "FlaUI value pattern"
+        finally:
+            value_pattern.set_value(original or "")

--- a/tests/ui/core/patterns/test_virtualized_item_pattern.py
+++ b/tests/ui/core/patterns/test_virtualized_item_pattern.py
@@ -1,0 +1,32 @@
+"""UI integration test for the VirtualizedItem pattern (GH-91)."""
+
+from flaui.core.definitions import ControlType
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestVirtualizedItemPattern:
+    """Tests for the VirtualizedItem pattern on list items that may be virtualized."""
+
+    def test_virtualized_item_pattern(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+        condition_factory: object,
+        is_pattern_supported: object,
+    ) -> None:
+        """Realize the first virtualized item found, or skip when none are virtualized."""
+        large_list_view = test_application.complex_controls_tab.large_list_view
+        items = large_list_view.find_all_descendants(
+            condition=condition_factory.by_control_type(ControlType.ListItem)  # type: ignore[attr-defined]
+        )
+        target = next(
+            (item for item in items if is_pattern_supported(item.patterns, "virtualized_item")),  # type: ignore[operator]
+            None,
+        )
+        if target is None:
+            pytest.skip("No virtualized items are present in the available controls")
+        # Realizing a virtualized item must not raise.
+        target.patterns.virtualized_item.pattern.realize()

--- a/tests/ui/core/patterns/test_window_pattern.py
+++ b/tests/ui/core/patterns/test_window_pattern.py
@@ -1,0 +1,33 @@
+"""UI integration test for the Window pattern on the application main window (GH-91).
+
+The main window is shared across the session, so the test reads the Window pattern state read-only
+rather than mutating the visual state (which would be flaky and could break sibling tests).
+"""
+
+from flaui.core.definitions import WindowVisualState
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestWindowPattern:
+    """Tests for the Window pattern on the shared application main window."""
+
+    def test_window_pattern(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> None:
+        """Read the Window pattern flags and visual state without mutating the shared window."""
+        window_pattern = test_application.main_window.patterns.window.pattern
+        assert_that(window_pattern, not_none())
+        assert isinstance(window_pattern.can_minimize.value, bool)
+        assert isinstance(window_pattern.can_maximize.value, bool)
+        assert window_pattern.is_modal.value is False
+        assert window_pattern.window_visual_state.value in (
+            WindowVisualState.Normal.value,
+            WindowVisualState.Maximized.value,
+            WindowVisualState.Minimized.value,
+        )


### PR DESCRIPTION
@
## Summary

Closes out the GH-91 pattern work on top of the merged 34-pattern surface (#117), bundled into a **single PR** to avoid paying for multiple slow serial AppVeyor runs.

The pattern wrappers are already 100% complete on `master`; this PR adds the missing **real UI integration tests** and **trims the CI gate**.

## Whats included

### UI integration tests (`tests/ui/core/patterns/`)
Real WinForms/WPF tests (across the UIA2/UIA3 × WinForms/WPF matrix) for the families that previously had only mocked unit tests:
- Value, Toggle, Selection/SelectionItem, Text/Text2, Window, Transform, Table/TableItem/GridItem, Scroll, MultipleView, LegacyIAccessible, ItemContainer, VirtualizedItem, Styles.
- Negative facade-plumbing tests for patterns with no exercisable control in the test apps (Dock, Annotation, Drag, DropTarget, ObjectModel, Spreadsheet/SpreadsheetItem, SynchronizedInput).
- New `is_pattern_supported` helper fixture that treats the UIA2 `NotSupportedByFrameworkException` as "unsupported", so tests guard uniformly across the matrix.
- Window/Transform tests are **read-only** so they dont mutate the shared session window.

**Local result:** `82 passed / 30 skipped` across the full matrix; unit suite `99 passed`.

### CI gate trim (`.appveyor.yml`)
The full Windows UI suite now runs **only where it gates a merge** — pull requests and pushes to `master`. Routine feature-branch pushes run the fast `tests/unit` subset. This cuts day-to-day turnaround for the serial AppVeyor gate. Documented in `CLAUDE.md`, `AGENTS.md`, and `docs/contributing/development.md`.

### Docs
Records that the facade has full parity with FlaUIs `IFrameworkPatterns` (34/34) and that **CustomNavigation** is a deliberate post-v1 non-goal (its absent from FlaUI.Core, living only in raw COM interop). Tracked in #121.

## Verification
- `uv run ruff check flaui tests` — clean
- `uv run pytest tests/unit` — 99 passed
- `uv run pytest tests/ui/core/patterns` — 82 passed / 30 skipped
- `uv run interrogate` — 99.3% (≥95%)
- `uv run zensical build --strict -f zensical.toml` — no issues
@