### PR TITLE
feat(core): ScrollBars, tools, XPath navigator & event handlers (GH-99/100/105/94/77)

### DIFF
--- a/docs/api/elements/scrollbar.md
+++ b/docs/api/elements/scrollbar.md
@@ -1,0 +1,11 @@
+# ScrollBar
+
+Horizontal and vertical scroll-bar elements. Both expose the shared RangeValue properties from
+``ScrollBarBase`` plus directional scroll methods. Obtain them via
+``element.as_horizontal_scroll_bar()`` / ``element.as_vertical_scroll_bar()``.
+
+::: flaui.core.automation_elements.ScrollBarBase
+
+::: flaui.core.automation_elements.HorizontalScrollBar
+
+::: flaui.core.automation_elements.VerticalScrollBar

--- a/docs/api/event_handlers.md
+++ b/docs/api/event_handlers.md
@@ -1,0 +1,21 @@
+# Event Handlers
+
+Register UI Automation event handlers from Python. The ``register_*`` methods on
+[`AutomationElement`](automation_element.md) and
+[`AutomationBase`](automation_base.md) return an `EventRegistration` handle that keeps the callback
+alive and can unregister it (also usable as a context manager).
+
+```python
+def on_invoked(element, event_id):
+    print("invoked!")
+
+registration = button.register_automation_event(
+    button.patterns.invoke.pattern.raw_pattern.EventIds.InvokedEvent,
+    TreeScope.Element,
+    on_invoked,
+)
+# ... later ...
+registration.unregister()
+```
+
+::: flaui.core.event_handlers.EventRegistration

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1,0 +1,16 @@
+# Tools
+
+Utility helpers ported from ``FlaUI.Core.Tools``. ``ItemRealizer`` realizes virtualized items,
+``AccessibilityTextResolver`` resolves MSAA role/state text, ``WindowsStoreAppLauncher`` launches UWP
+apps, ``LocalizedStrings`` exposes culture-aware UI strings, and ``SystemInfo`` reports CPU/memory
+metrics (pure-Python via ``psutil``).
+
+::: flaui.core.tools.ItemRealizer
+
+::: flaui.core.tools.AccessibilityTextResolver
+
+::: flaui.core.tools.WindowsStoreAppLauncher
+
+::: flaui.core.tools.LocalizedStrings
+
+::: flaui.core.tools.SystemInfo

--- a/docs/api/xpath_navigator.md
+++ b/docs/api/xpath_navigator.md
@@ -1,0 +1,8 @@
+# XPath Navigator
+
+Wraps the C# ``AutomationElementXPathNavigator`` for manual XPath-based navigation of the UI
+Automation tree. For most use cases prefer
+[`find_first_by_x_path`](automation_element.md) / `find_all_by_x_path`; obtain a navigator with
+``element.get_x_path_navigator()``.
+
+::: flaui.core.xpath_navigator.AutomationElementXPathNavigator

--- a/flaui/core/automation_base.py
+++ b/flaui/core/automation_base.py
@@ -180,13 +180,39 @@ class AutomationBase(BaseModel):
 
     @handle_csharp_exceptions
     def register_focus_changed_event(self, action: Any) -> Any:
-        """Register a focus-changed handler; passes through to C# (Action<AutomationElement>)."""
-        return self.raw_automation.RegisterFocusChangedEvent(action)
+        """Register a focus-changed handler.
+
+        :param action: Callback ``(element) -> None`` invoked when focus changes.
+        :return: An :class:`~flaui.core.event_handlers.EventRegistration` handle that keeps the
+            callback alive and can unregister it.
+        """
+        from flaui.core.automation_elements import AutomationElement as PyAutomationElement
+        from flaui.core.event_handlers import EventRegistration, make_focus_changed_delegate, safe_invoke
+
+        def _handler(sender: Any) -> None:
+            """Bridge the C# callback to the Python action."""
+            safe_invoke(action, PyAutomationElement(raw_element=sender))
+
+        handler = self.raw_automation.RegisterFocusChangedEvent(make_focus_changed_delegate(_handler))
+        return EventRegistration(
+            cs_handler=handler,
+            callback=_handler,
+            unregister=lambda h: self.raw_automation.UnregisterFocusChangedEvent(h),
+        )
 
     @handle_csharp_exceptions
     def unregister_focus_changed_event(self, event_handler: Any) -> None:
-        """Unregister a focus-changed handler returned by register_focus_changed_event."""
-        self.raw_automation.UnregisterFocusChangedEvent(event_handler)
+        """Unregister a focus-changed handler returned by :meth:`register_focus_changed_event`.
+
+        :param event_handler: The :class:`~flaui.core.event_handlers.EventRegistration` returned by
+            :meth:`register_focus_changed_event`, or a raw C# handler.
+        """
+        from flaui.core.event_handlers import EventRegistration
+
+        if isinstance(event_handler, EventRegistration):
+            event_handler.unregister()
+        else:
+            self.raw_automation.UnregisterFocusChangedEvent(event_handler)
 
     @handle_csharp_exceptions
     def unregister_all_events(self) -> None:

--- a/flaui/core/automation_elements.py
+++ b/flaui/core/automation_elements.py
@@ -42,7 +42,9 @@ from flaui.lib.system.drawing import (
 )
 
 if TYPE_CHECKING:
+    from flaui.core.event_handlers import EventRegistration
     from flaui.core.patterns import Patterns
+    from flaui.core.xpath_navigator import AutomationElementXPathNavigator
 
 # ================================================================================
 #   Element base Pydantic abstract class
@@ -566,6 +568,19 @@ class AutomationElement(ElementBase):
         return AutomationElement(raw_element=self.raw_element.FindFirstByXPath(x_path))
 
     @handle_csharp_exceptions
+    def get_x_path_navigator(self) -> "AutomationElementXPathNavigator":
+        """Return an XPath navigator rooted at this element for manual UIA-tree navigation.
+
+        For most use cases prefer :meth:`find_first_by_x_path` / :meth:`find_all_by_x_path`; this
+        exposes the underlying navigator for advanced traversal.
+
+        :return: An :class:`~flaui.core.xpath_navigator.AutomationElementXPathNavigator`.
+        """
+        from flaui.core.xpath_navigator import AutomationElementXPathNavigator
+
+        return AutomationElementXPathNavigator.from_element(self)
+
+    @handle_csharp_exceptions
     def find_first_child(self, condition: Optional[PropertyCondition] = None) -> AutomationElement:
         """Finds the first child.
 
@@ -715,63 +730,204 @@ class AutomationElement(ElementBase):
         return self.raw_element.IsPropertySupportedDirect(property)
 
     @handle_csharp_exceptions
-    def register_active_text_position_changed_event(self, tree_scope: TreeScope, action: Any) -> Any:
-        """Registers a active text position changed event.
+    def register_active_text_position_changed_event(
+        self, tree_scope: TreeScope, action: Callable[["AutomationElement", Any], None]
+    ) -> "EventRegistration":
+        """Register an active-text-position-changed event handler.
 
-        :param tree_scope: Treescope object
-        :param action: Action object
-        :return: Registered event
+        :param tree_scope: The tree scope to listen on.
+        :param action: Callback ``(element, text_range) -> None`` invoked when the event fires.
+        :return: An :class:`~flaui.core.event_handlers.EventRegistration` handle.
         """
-        # return self.raw_element.RegisterActiveTextPositionChangedEvent(tree_scope.value, action)
-        pass
+        from flaui.core.event_handlers import (
+            EventRegistration,
+            coerce_tree_scope,
+            make_active_text_position_delegate,
+            safe_invoke,
+        )
+        from flaui.core.text_range import TextRange
+
+        def _handler(sender: Any, text_range: Any) -> None:
+            """Bridge the C# callback to the Python action."""
+            safe_invoke(action, AutomationElement(raw_element=sender), TextRange(raw_text_range=text_range))
+
+        handler = self.raw_element.RegisterActiveTextPositionChangedEvent(
+            coerce_tree_scope(tree_scope), make_active_text_position_delegate(_handler)
+        )
+        return EventRegistration(
+            cs_handler=handler,
+            callback=_handler,
+            unregister=lambda h: self.framework_automation_element.UnregisterActiveTextPositionChangedEventHandler(h),
+        )
 
     @handle_csharp_exceptions
-    def register_automation_event(self, event: Any, tree_scope: TreeScope, action: Any) -> Any:
-        """Registers the given automation event.
+    def register_automation_event(
+        self, event: Any, tree_scope: TreeScope, action: Callable[["AutomationElement", Any], None]
+    ) -> "EventRegistration":
+        """Register an automation event handler.
 
-        :param event: Event object
-        :param tree_scope: Treescope object
-        :param action: Action object
-        :return: Registered event
+        :param event: The event to listen for (an ``EventId`` wrapper or a raw C# ``EventId``).
+        :param tree_scope: The tree scope to listen on.
+        :param action: Callback ``(element, event_id) -> None`` invoked when the event fires.
+        :return: An :class:`~flaui.core.event_handlers.EventRegistration` handle.
         """
-        # return self.raw_element.RegisterAutomationEvent(event, tree_scope, action)
-        pass
+        from flaui.core.event_handlers import (
+            EventRegistration,
+            coerce_event_id,
+            coerce_tree_scope,
+            make_automation_event_delegate,
+            safe_invoke,
+        )
+
+        def _handler(sender: Any, event_id: Any) -> None:
+            """Bridge the C# callback to the Python action."""
+            safe_invoke(action, AutomationElement(raw_element=sender), event_id)
+
+        handler = self.raw_element.RegisterAutomationEvent(
+            coerce_event_id(event), coerce_tree_scope(tree_scope), make_automation_event_delegate(_handler)
+        )
+        return EventRegistration(
+            cs_handler=handler,
+            callback=_handler,
+            unregister=lambda h: self.framework_automation_element.UnregisterAutomationEventHandler(h),
+        )
 
     @handle_csharp_exceptions
-    def register_notification_event(self) -> Any:
-        """Registers a notification event.
+    def register_notification_event(
+        self, tree_scope: TreeScope, action: Callable[["AutomationElement", Any, Any, str, str], None]
+    ) -> "EventRegistration":
+        """Register a notification event handler.
 
-        :return: None
+        :param tree_scope: The tree scope to listen on.
+        :param action: Callback ``(element, notification_kind, notification_processing, display_string,
+            activity_id) -> None`` invoked when the event fires.
+        :return: An :class:`~flaui.core.event_handlers.EventRegistration` handle.
         """
-        # self.raw_element.RegisterNotificationEvent
-        pass
+        from flaui.core.event_handlers import (
+            EventRegistration,
+            coerce_tree_scope,
+            make_notification_delegate,
+            safe_invoke,
+        )
+
+        def _handler(sender: Any, kind: Any, processing: Any, display_string: str, activity_id: str) -> None:
+            """Bridge the C# callback to the Python action."""
+            safe_invoke(action, AutomationElement(raw_element=sender), kind, processing, display_string, activity_id)
+
+        handler = self.raw_element.RegisterNotificationEvent(
+            coerce_tree_scope(tree_scope), make_notification_delegate(_handler)
+        )
+        return EventRegistration(
+            cs_handler=handler,
+            callback=_handler,
+            unregister=lambda h: self.framework_automation_element.UnregisterNotificationEventHandler(h),
+        )
 
     @handle_csharp_exceptions
-    def register_property_changed_event(self) -> Any:
-        """Registers a property changed event with the given property.
+    def register_property_changed_event(
+        self,
+        tree_scope: TreeScope,
+        action: Callable[["AutomationElement", Any, Any], None],
+        properties: List[Any],
+    ) -> "EventRegistration":
+        """Register a property-changed event handler for the given properties.
 
-        :return: None
+        :param tree_scope: The tree scope to listen on.
+        :param action: Callback ``(element, property_id, new_value) -> None`` invoked on change.
+        :param properties: Properties to watch (``PropertyId`` wrappers or raw C# ``PropertyId``).
+        :return: An :class:`~flaui.core.event_handlers.EventRegistration` handle.
         """
-        # self.raw_element.RegisterPropertyChangedEvent
-        pass
+        from System import Array  # pyright: ignore
+
+        from FlaUI.Core.Identifiers import PropertyId as CSPropertyId  # pyright: ignore
+
+        from flaui.core.event_handlers import (
+            EventRegistration,
+            coerce_property_id,
+            coerce_tree_scope,
+            make_property_changed_delegate,
+            safe_invoke,
+        )
+
+        def _handler(sender: Any, property_id: Any, new_value: Any) -> None:
+            """Bridge the C# callback to the Python action."""
+            safe_invoke(action, AutomationElement(raw_element=sender), property_id, new_value)
+
+        raw_properties = Array[CSPropertyId]([coerce_property_id(_) for _ in properties])
+        handler = self.raw_element.RegisterPropertyChangedEvent(
+            coerce_tree_scope(tree_scope), make_property_changed_delegate(_handler), raw_properties
+        )
+        return EventRegistration(
+            cs_handler=handler,
+            callback=_handler,
+            unregister=lambda h: self.framework_automation_element.UnregisterPropertyChangedEventHandler(h),
+        )
 
     @handle_csharp_exceptions
-    def register_structure_changed_event(self) -> Any:
-        """Registers a structure changed event.
+    def register_structure_changed_event(
+        self, tree_scope: TreeScope, action: Callable[["AutomationElement", Any, List[int]], None]
+    ) -> "EventRegistration":
+        """Register a structure-changed event handler.
 
-        :return: None
+        :param tree_scope: The tree scope to listen on.
+        :param action: Callback ``(element, change_type, runtime_id) -> None`` invoked on change.
+        :return: An :class:`~flaui.core.event_handlers.EventRegistration` handle.
         """
-        # self.raw_element.RegisterStructureChangedEvent
-        pass
+        from flaui.core.event_handlers import (
+            EventRegistration,
+            coerce_tree_scope,
+            make_structure_changed_delegate,
+            safe_invoke,
+        )
+
+        def _handler(sender: Any, change_type: Any, runtime_id: Any) -> None:
+            """Bridge the C# callback to the Python action."""
+            safe_invoke(action, AutomationElement(raw_element=sender), change_type, runtime_id)
+
+        handler = self.raw_element.RegisterStructureChangedEvent(
+            coerce_tree_scope(tree_scope), make_structure_changed_delegate(_handler)
+        )
+        return EventRegistration(
+            cs_handler=handler,
+            callback=_handler,
+            unregister=lambda h: self.framework_automation_element.UnregisterStructureChangedEventHandler(h),
+        )
 
     @handle_csharp_exceptions
-    def register_text_edit_text_changed_event_handler(self) -> Any:
-        """Registers a text edit text changed event.
+    def register_text_edit_text_changed_event_handler(
+        self,
+        tree_scope: TreeScope,
+        text_edit_change_type: Any,
+        action: Callable[["AutomationElement", Any, List[str]], None],
+    ) -> "EventRegistration":
+        """Register a text-edit text-changed event handler.
 
-        :return: None
+        :param tree_scope: The tree scope to listen on.
+        :param text_edit_change_type: The C# ``TextEditChangeType`` to listen for.
+        :param action: Callback ``(element, change_type, event_strings) -> None`` invoked on change.
+        :return: An :class:`~flaui.core.event_handlers.EventRegistration` handle.
         """
-        # self.raw_element.RegisterTextEditTextChangedEventHandler
-        pass
+        from flaui.core.event_handlers import (
+            EventRegistration,
+            coerce_tree_scope,
+            make_text_edit_delegate,
+            safe_invoke,
+        )
+
+        def _handler(sender: Any, change_type: Any, event_strings: Any) -> None:
+            """Bridge the C# callback to the Python action."""
+            safe_invoke(action, AutomationElement(raw_element=sender), change_type, event_strings)
+
+        handler = self.raw_element.RegisterTextEditTextChangedEventHandler(
+            coerce_tree_scope(tree_scope),
+            getattr(text_edit_change_type, "value", text_edit_change_type),
+            make_text_edit_delegate(_handler),
+        )
+        return EventRegistration(
+            cs_handler=handler,
+            callback=_handler,
+            unregister=lambda h: self.framework_automation_element.UnregisterTextEditTextChangedEventHandler(h),
+        )
 
     @handle_csharp_exceptions
     def right_click(self, move_mouse: bool = False) -> None:
@@ -927,14 +1083,14 @@ class AutomationElement(ElementBase):
         return GridHeaderItem(raw_element=CSGridHeaderItem(self.framework_automation_element))
 
     @handle_csharp_exceptions
-    # def as_horizontal_scroll_bar(self) -> HorizontalScrollBar:
-    #     """Converts the element to a HorizontalScrollBar.
+    def as_horizontal_scroll_bar(self) -> HorizontalScrollBar:
+        """Converts the element to a HorizontalScrollBar.
 
-    #     :return: HorizontalScrollBar element
-    #     """
-    #     # TODO: Put in HorizontalScrollBar element and update this line
-    #     from FlaUI.Core.AutomationElements import HorizontalScrollBar as CSHorizontalScrollBar  # pyright: ignore
-    #     return HorizontalScrollBar(raw_element=CSHorizontalScrollBar(self.framework_automation_element))
+        :return: HorizontalScrollBar element
+        """
+        from FlaUI.Core.AutomationElements.Scrolling import HorizontalScrollBar as CSHorizontalScrollBar  # pyright: ignore
+
+        return HorizontalScrollBar(raw_element=CSHorizontalScrollBar(self.framework_automation_element))
 
     @handle_csharp_exceptions
     def as_list_box(self) -> ListBox:
@@ -1097,13 +1253,14 @@ class AutomationElement(ElementBase):
         return TreeItem(raw_element=CSTreeItem(self.framework_automation_element))
 
     @handle_csharp_exceptions
-    # def as_vertical_scroll_bar(self) -> VerticalScrollBar:
-    #     """Converts the element to a VerticalScrollBar.
+    def as_vertical_scroll_bar(self) -> VerticalScrollBar:
+        """Converts the element to a VerticalScrollBar.
 
-    #     :return: VerticalScrollBar element
-    #     """
-    #     # TODO: Build VerticalScrollBar class and update this line
-    #     return VerticalScrollBar(raw_element=self.raw_element.AsVerticalScrollBar())
+        :return: VerticalScrollBar element
+        """
+        from FlaUI.Core.AutomationElements.Scrolling import VerticalScrollBar as CSVerticalScrollBar  # pyright: ignore
+
+        return VerticalScrollBar(raw_element=CSVerticalScrollBar(self.framework_automation_element))
 
     @handle_csharp_exceptions
     def as_window(self) -> Window:
@@ -2370,6 +2527,112 @@ class Spinner(AutomationElement):
     def decrement(self):
         """Performs a decrement."""
         self.raw_element.Decrement()
+
+
+class ScrollBarBase(AutomationElement):
+    """Base class for scroll bar elements, exposing the shared RangeValue properties."""
+
+    @property
+    @handle_csharp_exceptions
+    def value(self) -> float:
+        """The current scroll value.
+
+        :return: Current value.
+        """
+        return self.raw_element.Value
+
+    @property
+    @handle_csharp_exceptions
+    def minimum_value(self) -> float:
+        """The minimum scroll value.
+
+        :return: Minimum value.
+        """
+        return self.raw_element.MinimumValue
+
+    @property
+    @handle_csharp_exceptions
+    def maximum_value(self) -> float:
+        """The maximum scroll value.
+
+        :return: Maximum value.
+        """
+        return self.raw_element.MaximumValue
+
+    @property
+    @handle_csharp_exceptions
+    def small_change(self) -> float:
+        """The value of a small change (line scroll).
+
+        :return: Small change value.
+        """
+        return self.raw_element.SmallChange
+
+    @property
+    @handle_csharp_exceptions
+    def large_change(self) -> float:
+        """The value of a large change (page scroll).
+
+        :return: Large change value.
+        """
+        return self.raw_element.LargeChange
+
+    @property
+    @handle_csharp_exceptions
+    def is_read_only(self) -> bool:
+        """Whether the scroll bar value is read-only.
+
+        :return: ``True`` if read-only, else ``False``.
+        """
+        return self.raw_element.IsReadOnly
+
+
+class HorizontalScrollBar(ScrollBarBase):
+    """Class to interact with a horizontal scroll bar element."""
+
+    @handle_csharp_exceptions
+    def scroll_left(self) -> None:
+        """Scroll left by a small amount (line)."""
+        self.raw_element.ScrollLeft()
+
+    @handle_csharp_exceptions
+    def scroll_right(self) -> None:
+        """Scroll right by a small amount (line)."""
+        self.raw_element.ScrollRight()
+
+    @handle_csharp_exceptions
+    def scroll_left_large(self) -> None:
+        """Scroll left by a large amount (page)."""
+        self.raw_element.ScrollLeftLarge()
+
+    @handle_csharp_exceptions
+    def scroll_right_large(self) -> None:
+        """Scroll right by a large amount (page)."""
+        self.raw_element.ScrollRightLarge()
+
+
+class VerticalScrollBar(ScrollBarBase):
+    """Class to interact with a vertical scroll bar element."""
+
+    @handle_csharp_exceptions
+    def scroll_up(self) -> None:
+        """Scroll up by a small amount (line)."""
+        self.raw_element.ScrollUp()
+
+    @handle_csharp_exceptions
+    def scroll_down(self) -> None:
+        """Scroll down by a small amount (line)."""
+        self.raw_element.ScrollDown()
+
+    @handle_csharp_exceptions
+    def scroll_up_large(self) -> None:
+        """Scroll up by a large amount (page)."""
+        self.raw_element.ScrollUpLarge()
+
+    @handle_csharp_exceptions
+    def scroll_down_large(self) -> None:
+        """Scroll down by a large amount (page)."""
+        self.raw_element.ScrollDownLarge()
 
 
 class Tab(AutomationElement):

--- a/flaui/core/event_handlers.py
+++ b/flaui/core/event_handlers.py
@@ -1,0 +1,244 @@
+"""Support for registering UI Automation event handlers from Python.
+
+UIA event registration takes a callback that C# invokes (on a background thread) when the event
+fires. Two things make this tricky across the PythonNet boundary:
+
+1. **Lifetime** — C#/UIA only holds the delegate; if the Python callback is garbage collected the
+   callback target disappears. :class:`EventRegistration` keeps the callback (and the C# handler)
+   alive in a module-level registry until it is explicitly unregistered.
+2. **Threading** — events fire on UIA background threads. Callbacks therefore run off the main
+   thread; exceptions are logged rather than propagated (a raised exception cannot cross back into
+   the C# caller cleanly).
+
+Most users register through the methods on
+:class:`~flaui.core.automation_elements.AutomationElement` (e.g. ``register_automation_event``) and
+the matching methods on :class:`~flaui.core.automation_base.AutomationBase`, which return an
+:class:`EventRegistration` handle.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Set
+
+logger = logging.getLogger(__name__)
+
+# Strong references to live registrations so their callbacks are not garbage collected while C#
+# still holds the delegate.
+_live_registrations: Set["EventRegistration"] = set()
+_registry_lock = threading.Lock()
+
+
+class EventRegistration:
+    """Handle to a registered UI Automation event; keeps the callback alive and allows unregistering.
+
+    Use it as a context manager or call :meth:`unregister` / :meth:`dispose` when done.
+    """
+
+    def __init__(self, cs_handler: Any, callback: Callable[..., None], unregister: Callable[[Any], None]) -> None:
+        """Store the C# handler and callback and add the registration to the keep-alive registry.
+
+        :param cs_handler: The C# event-handler object returned by the native ``Register*`` call.
+        :param callback: The Python callback bridged to C# (kept alive to prevent GC).
+        :param unregister: A callable that unregisters ``cs_handler`` from C#.
+        """
+        self._cs_handler = cs_handler
+        self._callback = callback
+        self._unregister = unregister
+        self._active = True
+        with _registry_lock:
+            _live_registrations.add(self)
+
+    @property
+    def raw_handler(self) -> Any:
+        """Return the underlying C# event-handler object.
+
+        :return: The native handler returned by the ``Register*`` call.
+        """
+        return self._cs_handler
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether the registration is still active.
+
+        :return: ``True`` until :meth:`unregister` has been called.
+        """
+        return self._active
+
+    def unregister(self) -> None:
+        """Unregister the event handler from C# and drop the keep-alive reference."""
+        if not self._active:
+            return
+        try:
+            self._unregister(self._cs_handler)
+        finally:
+            self._active = False
+            with _registry_lock:
+                _live_registrations.discard(self)
+
+    def dispose(self) -> None:
+        """Alias for :meth:`unregister` (mirrors the C# disposable pattern)."""
+        self.unregister()
+
+    def __enter__(self) -> "EventRegistration":
+        """Return self for use as a context manager.
+
+        :return: This registration.
+        """
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        """Unregister the handler when leaving the ``with`` block.
+
+        :param exc: Exception info (unused).
+        """
+        self.unregister()
+
+
+def coerce_event_id(event: Any) -> Any:
+    """Return the raw C# ``EventId`` for an :class:`~flaui.core.identifiers.event_id.EventId` or raw value.
+
+    :param event: A Python ``EventId`` wrapper or a raw C# ``EventId``.
+    :return: The raw C# ``EventId``.
+    """
+    return getattr(event, "raw", event)
+
+
+def coerce_property_id(property_id: Any) -> Any:
+    """Return the raw C# ``PropertyId`` for a wrapper or raw value.
+
+    :param property_id: A Python ``PropertyId`` wrapper or a raw C# ``PropertyId``.
+    :return: The raw C# ``PropertyId``.
+    """
+    return getattr(property_id, "raw", property_id)
+
+
+def coerce_tree_scope(tree_scope: Any) -> Any:
+    """Return the raw C# ``TreeScope`` value for a :class:`~flaui.core.definitions.TreeScope` or raw value.
+
+    :param tree_scope: A Python ``TreeScope`` enum member or a raw C# ``TreeScope`` value.
+    :return: The raw C# ``TreeScope`` value.
+    """
+    return getattr(tree_scope, "value", tree_scope)
+
+
+def safe_invoke(callback: Callable[..., None], *args: Any) -> None:
+    """Invoke a user callback, logging (not raising) any exception.
+
+    UIA events fire on background threads where a raised exception cannot cross back into the C#
+    caller, so failures are logged instead.
+
+    :param callback: The user-supplied callback.
+    :param args: Arguments to pass to the callback.
+    """
+    try:
+        callback(*args)
+    except Exception:  # noqa: BLE001 - never let an exception escape into the C# event thread
+        logger.exception("Unhandled exception in UI Automation event callback")
+
+
+# ---------------------------------------------------------------------------
+# Typed C# delegate builders.
+#
+# PythonNet does not auto-convert a plain Python function to a generic ``Action<...>`` when several
+# overloads exist, so each register call needs an explicitly typed delegate. These builders import
+# the C# types lazily (after the bridge is set up) and wrap the given Python function.
+# ---------------------------------------------------------------------------
+
+
+def make_automation_event_delegate(func: Callable[..., None]) -> Any:
+    """Wrap a function as ``Action<AutomationElement, EventId>``.
+
+    :param func: The bridge function to wrap.
+    :return: A typed C# delegate.
+    """
+    from System import Action  # pyright: ignore
+
+    from FlaUI.Core.AutomationElements import AutomationElement as CSAutomationElement  # pyright: ignore
+    from FlaUI.Core.Identifiers import EventId as CSEventId  # pyright: ignore
+
+    return Action[CSAutomationElement, CSEventId](func)
+
+
+def make_property_changed_delegate(func: Callable[..., None]) -> Any:
+    """Wrap a function as ``Action<AutomationElement, PropertyId, object>``.
+
+    :param func: The bridge function to wrap.
+    :return: A typed C# delegate.
+    """
+    from System import Action, Object  # pyright: ignore
+
+    from FlaUI.Core.AutomationElements import AutomationElement as CSAutomationElement  # pyright: ignore
+    from FlaUI.Core.Identifiers import PropertyId as CSPropertyId  # pyright: ignore
+
+    return Action[CSAutomationElement, CSPropertyId, Object](func)
+
+
+def make_structure_changed_delegate(func: Callable[..., None]) -> Any:
+    """Wrap a function as ``Action<AutomationElement, StructureChangeType, int[]>``.
+
+    :param func: The bridge function to wrap.
+    :return: A typed C# delegate.
+    """
+    from System import Action, Array, Int32  # pyright: ignore
+
+    from FlaUI.Core.AutomationElements import AutomationElement as CSAutomationElement  # pyright: ignore
+    from FlaUI.Core.Definitions import StructureChangeType  # pyright: ignore
+
+    return Action[CSAutomationElement, StructureChangeType, Array[Int32]](func)
+
+
+def make_notification_delegate(func: Callable[..., None]) -> Any:
+    """Wrap a function as the notification ``Action<AutomationElement, NotificationKind, ...>``.
+
+    :param func: The bridge function to wrap.
+    :return: A typed C# delegate.
+    """
+    from System import Action, String  # pyright: ignore
+
+    from FlaUI.Core.AutomationElements import AutomationElement as CSAutomationElement  # pyright: ignore
+    from FlaUI.Core.Definitions import NotificationKind, NotificationProcessing  # pyright: ignore
+
+    return Action[CSAutomationElement, NotificationKind, NotificationProcessing, String, String](func)
+
+
+def make_focus_changed_delegate(func: Callable[..., None]) -> Any:
+    """Wrap a function as ``Action<AutomationElement>``.
+
+    :param func: The bridge function to wrap.
+    :return: A typed C# delegate.
+    """
+    from System import Action  # pyright: ignore
+
+    from FlaUI.Core.AutomationElements import AutomationElement as CSAutomationElement  # pyright: ignore
+
+    return Action[CSAutomationElement](func)
+
+
+def make_active_text_position_delegate(func: Callable[..., None]) -> Any:
+    """Wrap a function as ``Action<AutomationElement, ITextRange>``.
+
+    :param func: The bridge function to wrap.
+    :return: A typed C# delegate.
+    """
+    from System import Action  # pyright: ignore
+
+    from FlaUI.Core import ITextRange  # pyright: ignore
+    from FlaUI.Core.AutomationElements import AutomationElement as CSAutomationElement  # pyright: ignore
+
+    return Action[CSAutomationElement, ITextRange](func)
+
+
+def make_text_edit_delegate(func: Callable[..., None]) -> Any:
+    """Wrap a function as ``Action<AutomationElement, TextEditChangeType, string[]>``.
+
+    :param func: The bridge function to wrap.
+    :return: A typed C# delegate.
+    """
+    from System import Action, Array, String  # pyright: ignore
+
+    from FlaUI.Core.AutomationElements import AutomationElement as CSAutomationElement  # pyright: ignore
+    from FlaUI.Core.Definitions import TextEditChangeType  # pyright: ignore
+
+    return Action[CSAutomationElement, TextEditChangeType, Array[String]](func)

--- a/flaui/core/tools.py
+++ b/flaui/core/tools.py
@@ -8,7 +8,12 @@ These can be actively used during test automation for reliability and improved p
 
 from collections.abc import Iterable
 import time
-from typing import Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+
+import psutil
+
+if TYPE_CHECKING:
+    from flaui.core.automation_elements import AutomationElement
 
 T = TypeVar("T")
 
@@ -381,6 +386,201 @@ class Retry:
         :return: True if the timeout has been reached, False otherwise.
         """
         return (time.monotonic() - start_time) * 1000.0 > timeout
+
+
+class ItemRealizer:
+    """Realizes virtualized items in a container so they become full members of the automation tree.
+
+    Mirrors C# ``FlaUI.Core.Tools.ItemRealizer``; delegates to the native implementation, which uses
+    the Scroll and ItemContainer patterns to walk and realize each item.
+    """
+
+    @staticmethod
+    def realize_items(item_container_element: "AutomationElement") -> None:
+        """Realize all virtualized items in the given container element.
+
+        :param item_container_element: The container whose items should be realized.
+        """
+        from FlaUI.Core.Tools import ItemRealizer as CSItemRealizer  # pyright: ignore
+
+        CSItemRealizer.RealizeItems(item_container_element.raw_element)
+
+
+class AccessibilityTextResolver:
+    """Resolves human-readable text for MSAA accessibility roles and states.
+
+    Mirrors C# ``FlaUI.Core.Tools.AccessibilityTextResolver`` (a thin wrapper over ``oleacc``).
+    Roles/states are the C# ``AccessibilityRole`` / ``AccessibilityState`` values, e.g. those
+    returned by ``element.patterns.legacy_i_accessible.pattern.role.value``.
+    """
+
+    @staticmethod
+    def get_role_text(role: Any) -> str:
+        """Return the localized text for an accessibility role.
+
+        :param role: The C# ``AccessibilityRole`` value.
+        :return: Human-readable role text (e.g. ``"push button"``).
+        """
+        from FlaUI.Core.Tools import AccessibilityTextResolver as CSResolver  # pyright: ignore
+
+        return CSResolver.GetRoleText(role)
+
+    @staticmethod
+    def get_state_bit_text(state: Any) -> str:
+        """Return the localized text for a single accessibility state bit.
+
+        :param state: The C# ``AccessibilityState`` value (single bit).
+        :return: Human-readable state text (e.g. ``"focused"``).
+        """
+        from FlaUI.Core.Tools import AccessibilityTextResolver as CSResolver  # pyright: ignore
+
+        return CSResolver.GetStateBitText(state)
+
+    @staticmethod
+    def get_state_text(state: Any) -> str:
+        """Return the comma-separated localized text for all set accessibility state flags.
+
+        :param state: The C# ``AccessibilityState`` value (possibly multiple flags).
+        :return: Comma-separated human-readable state text.
+        """
+        from FlaUI.Core.Tools import AccessibilityTextResolver as CSResolver  # pyright: ignore
+
+        return CSResolver.GetStateText(state)
+
+
+class WindowsStoreAppLauncher:
+    """Launches Windows Store (UWP) apps by their Application User Model ID.
+
+    Mirrors C# ``FlaUI.Core.Tools.WindowsStoreAppLauncher``, which uses the COM
+    ``IApplicationActivationManager`` to activate the app.
+    """
+
+    @staticmethod
+    def launch(app_user_model_id: str, arguments: str = "") -> int:
+        """Launch a Windows Store app and return its process id.
+
+        :param app_user_model_id: The Application User Model ID of the app to launch.
+        :param arguments: Arguments to pass to the app, defaults to an empty string.
+        :return: The process id of the launched app.
+        """
+        from FlaUI.Core.Tools import WindowsStoreAppLauncher as CSLauncher  # pyright: ignore
+
+        return int(CSLauncher.Launch(app_user_model_id, arguments).Id)
+
+
+class LocalizedStrings:
+    """Culture-aware UI strings used by FlaUI (e.g. scroll-bar names per framework/locale).
+
+    Mirrors C# ``FlaUI.Core.Tools.LocalizedStrings``; values are read from the native class, which
+    selects strings based on the current OS culture.
+    """
+
+    @staticmethod
+    def _get(name: str) -> str:
+        """Return a named localized string from the C# ``LocalizedStrings`` class.
+
+        :param name: The C# property name (PascalCase).
+        :return: The localized string value.
+        """
+        from FlaUI.Core.Tools import LocalizedStrings as CSLocalizedStrings  # pyright: ignore
+
+        return getattr(CSLocalizedStrings, name)
+
+    @classmethod
+    def horizontal_scroll_bar(cls) -> str:
+        """Return the localized name of a horizontal scroll bar.
+
+        :return: Localized horizontal scroll-bar name.
+        """
+        return cls._get("HorizontalScrollBar")
+
+    @classmethod
+    def vertical_scroll_bar(cls) -> str:
+        """Return the localized name of a vertical scroll bar.
+
+        :return: Localized vertical scroll-bar name.
+        """
+        return cls._get("VerticalScrollBar")
+
+
+class SystemInfo:
+    """System CPU and memory metrics, implemented in pure Python via :mod:`psutil`.
+
+    Python-native equivalent of C# ``FlaUI.Core.Tools.SystemInfo`` (the C# version uses
+    ``PerformanceCounter`` / WMI). Memory values are bytes; percentages are 0-100 floats.
+    """
+
+    @staticmethod
+    def cpu_usage() -> float:
+        """Return the current system-wide CPU utilization as a percentage (0-100).
+
+        :return: CPU usage percentage.
+        """
+        return psutil.cpu_percent()
+
+    @staticmethod
+    def physical_memory_total() -> int:
+        """Return the total physical memory in bytes.
+
+        :return: Total physical memory (bytes).
+        """
+        return psutil.virtual_memory().total
+
+    @staticmethod
+    def physical_memory_free() -> int:
+        """Return the available physical memory in bytes.
+
+        :return: Available physical memory (bytes).
+        """
+        return psutil.virtual_memory().available
+
+    @staticmethod
+    def physical_memory_used() -> int:
+        """Return the used physical memory in bytes.
+
+        :return: Used physical memory (bytes).
+        """
+        return psutil.virtual_memory().used
+
+    @staticmethod
+    def physical_memory_used_percent() -> float:
+        """Return the used physical memory as a percentage (0-100).
+
+        :return: Used physical memory percentage.
+        """
+        return psutil.virtual_memory().percent
+
+    @staticmethod
+    def physical_memory_free_percent() -> float:
+        """Return the free physical memory as a percentage (0-100).
+
+        :return: Free physical memory percentage.
+        """
+        return 100.0 - psutil.virtual_memory().percent
+
+    @staticmethod
+    def virtual_memory_total() -> int:
+        """Return the total virtual (swap/page-file) memory in bytes.
+
+        :return: Total virtual memory (bytes).
+        """
+        return psutil.swap_memory().total
+
+    @staticmethod
+    def virtual_memory_free() -> int:
+        """Return the free virtual (swap/page-file) memory in bytes.
+
+        :return: Free virtual memory (bytes).
+        """
+        return psutil.swap_memory().free
+
+    @staticmethod
+    def virtual_memory_used() -> int:
+        """Return the used virtual (swap/page-file) memory in bytes.
+
+        :return: Used virtual memory (bytes).
+        """
+        return psutil.swap_memory().used
 
     # @staticmethod
     # def

--- a/flaui/core/xpath_navigator.py
+++ b/flaui/core/xpath_navigator.py
@@ -1,0 +1,134 @@
+"""Python wrapper for the C# ``FlaUI.Core.AutomationElementXPathNavigator``.
+
+The navigator is a custom ``System.Xml.XPath.XPathNavigator`` that walks the UI Automation tree, the
+same engine that backs :meth:`~flaui.core.automation_elements.AutomationElement.find_first_by_x_path`
+and :meth:`~flaui.core.automation_elements.AutomationElement.find_all_by_x_path`. Most users only
+need those high-level methods; this wrapper exposes the navigator directly for advanced, manual tree
+navigation while keeping 1:1 parity with FlaUI C#.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from flaui.lib.exceptions import handle_csharp_exceptions
+
+if TYPE_CHECKING:
+    from flaui.core.automation_elements import AutomationElement
+
+
+class AutomationElementXPathNavigator(BaseModel):
+    """Wraps the C# ``AutomationElementXPathNavigator`` for XPath-based tree navigation."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    raw_navigator: Any = Field(..., description="The underlying C# AutomationElementXPathNavigator object")
+
+    @classmethod
+    def from_element(cls, element: "AutomationElement") -> "AutomationElementXPathNavigator":
+        """Create a navigator rooted at the given element.
+
+        :param element: The element to use as the navigation root.
+        :return: A new :class:`AutomationElementXPathNavigator`.
+        """
+        from FlaUI.Core import AutomationElementXPathNavigator as CSNavigator  # pyright: ignore
+
+        return cls(raw_navigator=CSNavigator(element.raw_element))
+
+    @property
+    @handle_csharp_exceptions
+    def current_element(self) -> "AutomationElement":
+        """Return the element at the navigator's current position.
+
+        :return: The current :class:`~flaui.core.automation_elements.AutomationElement`.
+        """
+        from flaui.core.automation_elements import AutomationElement
+
+        return AutomationElement(raw_element=self.raw_navigator.UnderlyingObject)
+
+    @property
+    @handle_csharp_exceptions
+    def name(self) -> str:
+        """Return the name of the current node (its control type, or attribute name).
+
+        :return: The node name.
+        """
+        return self.raw_navigator.Name
+
+    @property
+    @handle_csharp_exceptions
+    def value(self) -> str:
+        """Return the string value of the current node.
+
+        :return: The node value.
+        """
+        return self.raw_navigator.Value
+
+    @property
+    @handle_csharp_exceptions
+    def node_type(self) -> str:
+        """Return the XPath node type of the current node (e.g. ``Root``, ``Element``).
+
+        :return: The node type as a string.
+        """
+        return str(self.raw_navigator.NodeType)
+
+    @handle_csharp_exceptions
+    def clone(self) -> "AutomationElementXPathNavigator":
+        """Return an independent copy of this navigator at the same position.
+
+        :return: A cloned navigator.
+        """
+        return AutomationElementXPathNavigator(raw_navigator=self.raw_navigator.Clone())
+
+    @handle_csharp_exceptions
+    def move_to_root(self) -> None:
+        """Move the navigator to the root element."""
+        self.raw_navigator.MoveToRoot()
+
+    @handle_csharp_exceptions
+    def move_to_first_child(self) -> bool:
+        """Move to the first child of the current element.
+
+        :return: ``True`` if moved, ``False`` if there is no child.
+        """
+        return self.raw_navigator.MoveToFirstChild()
+
+    @handle_csharp_exceptions
+    def move_to_parent(self) -> bool:
+        """Move to the parent of the current element.
+
+        :return: ``True`` if moved, ``False`` if already at the root.
+        """
+        return self.raw_navigator.MoveToParent()
+
+    @handle_csharp_exceptions
+    def move_to_next(self) -> bool:
+        """Move to the next sibling of the current element.
+
+        :return: ``True`` if moved, ``False`` if there is no next sibling.
+        """
+        return self.raw_navigator.MoveToNext()
+
+    @handle_csharp_exceptions
+    def move_to_previous(self) -> bool:
+        """Move to the previous sibling of the current element.
+
+        :return: ``True`` if moved, ``False`` if there is no previous sibling.
+        """
+        return self.raw_navigator.MoveToPrevious()
+
+    @handle_csharp_exceptions
+    def get_attribute(self, name: str) -> Optional[str]:
+        """Return the value of a named attribute on the current element.
+
+        Supported attribute names mirror the C# navigator: ``AutomationId``, ``Name``, ``ClassName``,
+        ``HelpText``, ``IsPassword``, ``FullDescription``, ``ItemType``, ``AcceleratorKey``,
+        ``AccessKey``, ``IsEnabled``, ``IsOffscreen``, ``ProcessId``.
+
+        :param name: The attribute name.
+        :return: The attribute value, or an empty string when unset.
+        """
+        return self.raw_navigator.GetAttribute(name, "")

--- a/tests/ui/core/patterns/test_invoke_pattern.py
+++ b/tests/ui/core/patterns/test_invoke_pattern.py
@@ -9,10 +9,11 @@ TODO: Update this test once RegisterAutomationEvent is ported to Python wrapper.
 Currently simplified without event handling.
 """
 
+import threading
 from typing import Any, Generator
 
 from flaui.core.automation_elements import AutomationElement
-from flaui.core.definitions import ControlType
+from flaui.core.definitions import ControlType, TreeScope
 from hamcrest import assert_that, not_none
 import pytest
 
@@ -43,53 +44,29 @@ class TestInvokePattern:
         button = tab_item.find_first_descendant(condition=test_application._cf.by_automation_id("InvokableButton"))
         yield button
 
-    @pytest.mark.bug(
-        id="GH-77",
-        url="https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/77",
-        reason="RegisterAutomationEvent not yet ported to Python wrapper",
-    )
-    @pytest.mark.skip(reason="TODO: Implement once RegisterAutomationEvent is ported to Python wrapper")
     def test_invoke_with_event(
         self,
         invokable_button: AutomationElement,
     ) -> None:
-        """Test invoke pattern and event on InvokableButton control.
-
-        This is a simplified version that will be enhanced once event handling is available.
-        """
+        """Invoke the button and verify the registered automation event fires (GH-77)."""
         assert_that(invokable_button, not_none())
-        orig_button_text = invokable_button.properties.name  # noqa: F841
         invoke_pattern = invokable_button.patterns.invoke.pattern
         assert_that(invoke_pattern, not_none())
 
-        # TODO: Add event registration when RegisterAutomationEvent is ported
-        # For now, just test basic invoke without event verification
-        invoke_pattern.invoke()
-        # Button text should change after invoke (verification without event handler)
-        # This may need refinement based on actual behavior
+        invoke_fired = threading.Event()
 
+        def on_invoked(element: AutomationElement, event_id: Any) -> None:
+            """Set the threading event when the Invoked event fires."""
+            invoke_fired.set()
 
-#         orig_button_text = invokable_button.properties.name
-#         invoke_pattern = (
-#             invokable_button.patterns.Invoke.Pattern
-#         )  # TODO: Move Patterns to Py-wrapper once it is created
-#         assert_that(invoke_pattern, not_none())
-#         invoke_fired = threading.Event()
-
-#         # Register event handler (PythonNet interop, may need adjustment for your wrapper)
-#         def on_invoked(element, event_id):
-#             invoke_fired.set()
-
-#         # This assumes RegisterAutomationEvent is exposed and works as in C#
-#         registered_event = invokable_button.register_automation_event(
-#             invoke_pattern.EventIds.InvokedEvent,
-#             0,
-#             on_invoked,  # 0 = TreeScope.Element
-#         )
-#         invoke_pattern.Invoke()
-#         event_received = invoke_fired.wait(timeout=1.0)
-#         assert event_received, "Invoke event was not received within timeout"
-#         assert invokable_button.properties.name != orig_button_text, "Button text should change after invoke"
-#         # Clean up event handler if needed
-#         if hasattr(registered_event, "dispose"):
-#             registered_event.dispose()
+        # EventIds is exposed on the raw C# pattern (Automation.EventLibrary.Invoke).
+        invoked_event_id = invoke_pattern.raw_pattern.EventIds.InvokedEvent
+        registration = invokable_button.register_automation_event(
+            invoked_event_id, TreeScope.Element, on_invoked
+        )
+        try:
+            invoke_pattern.invoke()
+            assert invoke_fired.wait(timeout=5.0), "Invoke event was not received within timeout"
+        finally:
+            registration.unregister()
+        assert registration.is_active is False

--- a/tests/ui/core/test_item_realizer.py
+++ b/tests/ui/core/test_item_realizer.py
@@ -1,0 +1,22 @@
+"""UI integration test for the ItemRealizer tool (GH-100)."""
+
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestItemRealizer:
+    """Tests for realizing virtualized items in a container."""
+
+    def test_realize_items_on_large_list_view(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> None:
+        """Realizing the items of the LargeListView completes without raising."""
+        from flaui.core.tools import ItemRealizer
+
+        large_list_view = test_application.complex_controls_tab.large_list_view
+        # Should walk and realize all (virtualized) items without error.
+        ItemRealizer.realize_items(large_list_view)

--- a/tests/ui/core/test_scrollbar.py
+++ b/tests/ui/core/test_scrollbar.py
@@ -1,0 +1,49 @@
+"""UI integration tests for ScrollBar elements (GH-99)."""
+
+from typing import Any, Generator
+
+from flaui.core.automation_elements import AutomationElement, HorizontalScrollBar, VerticalScrollBar
+from flaui.core.definitions import ControlType
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestScrollBar:
+    """Tests for HorizontalScrollBar/VerticalScrollBar wrappers on a scrollable list view."""
+
+    @pytest.fixture(name="scroll_bar")
+    def get_scroll_bar(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+        condition_factory: Any,
+    ) -> Generator[AutomationElement, Any, None]:
+        """Fixture to get the first ScrollBar within the LargeListView, or skip if none present.
+
+        :param test_application: Test application elements.
+        :param condition_factory: Condition factory for building search conditions.
+        :yield: A ScrollBar automation element.
+        """
+        large_list_view = test_application.complex_controls_tab.large_list_view
+        scroll_bars = large_list_view.find_all_descendants(
+            condition=condition_factory.by_control_type(ControlType.ScrollBar)
+        )
+        if not scroll_bars:
+            pytest.skip("No ScrollBar present in the LargeListView for this runtime")
+        yield scroll_bars[0]
+
+    def test_scroll_bar_range_properties(self, scroll_bar: AutomationElement) -> None:
+        """Read the shared RangeValue properties through the scroll-bar wrapper."""
+        bar = scroll_bar.as_vertical_scroll_bar()
+        assert isinstance(bar, VerticalScrollBar)
+        assert bar.minimum_value <= bar.value <= bar.maximum_value
+        assert isinstance(bar.is_read_only, bool)
+        assert bar.small_change >= 0
+        assert bar.large_change >= 0
+
+    def test_scroll_bar_converters(self, scroll_bar: AutomationElement) -> None:
+        """Both scroll-bar converters return the correctly typed wrapper."""
+        assert isinstance(scroll_bar.as_horizontal_scroll_bar(), HorizontalScrollBar)
+        assert isinstance(scroll_bar.as_vertical_scroll_bar(), VerticalScrollBar)

--- a/tests/ui/core/test_xpath_navigator.py
+++ b/tests/ui/core/test_xpath_navigator.py
@@ -1,0 +1,47 @@
+"""UI integration tests for the AutomationElementXPathNavigator wrapper (GH-105)."""
+
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.xpath_navigator import AutomationElementXPathNavigator
+from hamcrest import assert_that, not_none
+import pytest
+
+from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
+from tests.test_utilities.elements.wpf_application import WPFApplicationElements
+
+
+@pytest.mark.usefixtures("test_application", "ui_automation_type", "test_application_type")
+class TestXPathNavigator:
+    """Tests for navigating the UIA tree via the XPath navigator."""
+
+    def test_navigator_starts_at_root(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> None:
+        """A fresh navigator is positioned at the root element (the window)."""
+        navigator = test_application.main_window.get_x_path_navigator()
+        assert isinstance(navigator, AutomationElementXPathNavigator)
+        assert "Root" in navigator.node_type
+        assert_that(navigator.current_element, not_none())
+        assert isinstance(navigator.current_element, AutomationElement)
+
+    def test_navigator_moves_through_tree(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> None:
+        """The navigator can move to a child and back to the root."""
+        navigator = test_application.main_window.get_x_path_navigator()
+        if not navigator.move_to_first_child():
+            pytest.skip("Root element has no children to navigate to")
+        # On a child node the name is the control type string; it should be non-empty.
+        assert isinstance(navigator.name, str) and navigator.name
+        navigator.move_to_root()
+        assert "Root" in navigator.node_type
+
+    def test_navigator_get_attribute(
+        self,
+        test_application: WinFormsApplicationElements | WPFApplicationElements,
+    ) -> None:
+        """The navigator exposes element attributes by name."""
+        navigator = test_application.main_window.get_x_path_navigator()
+        # Name attribute should resolve to a string (possibly empty) without raising.
+        assert isinstance(navigator.get_attribute("Name"), str)

--- a/tests/unit/core/test_tools_extra.py
+++ b/tests/unit/core/test_tools_extra.py
@@ -1,0 +1,76 @@
+"""Unit tests for the additional tools/utilities (GH-100).
+
+SystemInfo is pure Python (via psutil); LocalizedStrings and AccessibilityTextResolver delegate to
+C# and only need the PythonNet bridge (set up by the global conftest), not a running application.
+"""
+
+from flaui.core.tools import AccessibilityTextResolver, LocalizedStrings, SystemInfo, WindowsStoreAppLauncher
+import pytest
+
+
+class TestSystemInfo:
+    """Tests for the pure-Python SystemInfo metrics."""
+
+    def test_cpu_usage_is_a_percentage(self) -> None:
+        """CPU usage is a float between 0 and 100."""
+        usage = SystemInfo.cpu_usage()
+        assert isinstance(usage, float)
+        assert 0.0 <= usage <= 100.0
+
+    def test_physical_memory_metrics(self) -> None:
+        """Physical memory totals are positive and percentages are within range."""
+        assert SystemInfo.physical_memory_total() > 0
+        assert SystemInfo.physical_memory_free() >= 0
+        assert SystemInfo.physical_memory_used() >= 0
+        assert 0.0 <= SystemInfo.physical_memory_used_percent() <= 100.0
+        assert 0.0 <= SystemInfo.physical_memory_free_percent() <= 100.0
+
+    def test_virtual_memory_metrics(self) -> None:
+        """Virtual (swap) memory metrics are non-negative integers."""
+        assert SystemInfo.virtual_memory_total() >= 0
+        assert SystemInfo.virtual_memory_free() >= 0
+        assert SystemInfo.virtual_memory_used() >= 0
+
+
+class TestLocalizedStrings:
+    """Tests for the culture-aware localized strings."""
+
+    def test_scroll_bar_names_are_non_empty(self) -> None:
+        """Horizontal and vertical scroll-bar names resolve to non-empty strings."""
+        assert isinstance(LocalizedStrings.horizontal_scroll_bar(), str)
+        assert LocalizedStrings.horizontal_scroll_bar()
+        assert isinstance(LocalizedStrings.vertical_scroll_bar(), str)
+        assert LocalizedStrings.vertical_scroll_bar()
+
+
+class TestAccessibilityTextResolver:
+    """Tests for resolving MSAA role/state text via oleacc."""
+
+    def test_get_role_text(self) -> None:
+        """A known accessibility role resolves to non-empty human-readable text."""
+        from FlaUI.Core.WindowsAPI import AccessibilityRole  # pyright: ignore
+        import System  # pyright: ignore
+
+        roles = list(System.Enum.GetValues(AccessibilityRole))
+        # Use a role other than the first (which is typically a 'none'/0 value).
+        role = roles[1] if len(roles) > 1 else roles[0]
+        text = AccessibilityTextResolver.get_role_text(role)
+        assert isinstance(text, str)
+
+    def test_get_state_text(self) -> None:
+        """An accessibility state resolves to a string."""
+        from FlaUI.Core.WindowsAPI import AccessibilityState  # pyright: ignore
+        import System  # pyright: ignore
+
+        states = list(System.Enum.GetValues(AccessibilityState))
+        text = AccessibilityTextResolver.get_state_text(states[0])
+        assert isinstance(text, str)
+
+
+class TestWindowsStoreAppLauncher:
+    """Tests for the Windows Store app launcher surface."""
+
+    def test_invalid_app_id_raises(self) -> None:
+        """Launching a non-existent app id raises rather than silently failing."""
+        with pytest.raises(Exception):  # noqa: B017,PT011 - native COM error type varies
+            WindowsStoreAppLauncher.launch("FlaUI.NonExistentApp!App")

--- a/zensical.toml
+++ b/zensical.toml
@@ -28,6 +28,8 @@ nav = [
       { "Automation Element" = "api/automation_element.md" },
       { "Identifiers" = "api/identifiers.md" },
       { "Patterns" = "api/patterns.md" },
+      { "XPath Navigator" = "api/xpath_navigator.md" },
+      { "Event Handlers" = "api/event_handlers.md" },
     ] },
     { "Input" = [
       { "Mouse" = "api/mouse.md" },
@@ -36,6 +38,7 @@ nav = [
     ] },
     { "Tools" = [
       { "Retry" = "api/retry.md" },
+      { "Tools & Utilities" = "api/tools.md" },
       { "Cache Request" = "api/cache_request.md" },
       { "Drawing" = "api/drawing.md" },
       { "Collections" = "api/collections.md" },
@@ -57,6 +60,7 @@ nav = [
       { "MenuItem" = "api/elements/menu_item.md" },
       { "ProgressBar" = "api/elements/progressbar.md" },
       { "RadioButton" = "api/elements/radiobutton.md" },
+      { "ScrollBar" = "api/elements/scrollbar.md" },
       { "Slider" = "api/elements/slider.md" },
       { "Spinner" = "api/elements/spinner.md" },
       { "Tab" = "api/elements/tab.md" },


### PR DESCRIPTION
@
## Summary

Four roadmap items bundled into a single PR (solo dev + slow serial AppVeyor gate). All built on top of the merged pattern surface.

## Whats included

### ScrollBar elements — GH-99
`ScrollBarBase` / `HorizontalScrollBar` / `VerticalScrollBar` wrapping `FlaUI.Core.AutomationElements.Scrolling`; the previously commented-out `as_horizontal_scroll_bar` / `as_vertical_scroll_bar` converters are now implemented.

### Tools / utilities — GH-100
In `flaui/core/tools.py`: `ItemRealizer`, `AccessibilityTextResolver`, `WindowsStoreAppLauncher`, `LocalizedStrings` (PythonNet wrappers) and `SystemInfo` (pure-Python via `psutil`, per the projects prefer-Python-for-generic-utils guidance).

### XPath navigator — GH-105
`flaui/core/xpath_navigator.AutomationElementXPathNavigator` wrapping the C# navigator, plus `AutomationElement.get_x_path_navigator()`. (The high-level `find_first_by_x_path` / `find_all_by_x_path` already use this engine internally.)

### Event handler system — GH-94, GH-77
- New `flaui/core/event_handlers.py`: an `EventRegistration` keep-alive handle (UIA events fire on background threads, so the delegate/callback must survive GC) and typed `Action<...>` delegate builders (PythonNet wont auto-convert a plain function when overloads exist).
- Implemented all six `AutomationElement.register_*` event methods (previously no-op stubs) and made `AutomationBase.register_focus_changed_event` keep-alive.
- **Unblocks the skipped `InvokePattern` event test** (`test_invoke_with_event`).

## Tests & docs
- UI tests: ScrollBars, XPath navigator, ItemRealizer, invoke event.
- Unit tests: SystemInfo / LocalizedStrings / AccessibilityTextResolver / StoreAppLauncher.
- API reference pages added and registered in the docs nav.

## Verification (local)
- `uv run ruff check flaui tests` — clean
- `uv run pytest tests/unit` — 106 passed
- New UI tests — 22 passed / 6 skipped (skips: WinForms combos with no scroll bar)
- `uv run interrogate` — 99.3% (≥95%)
- `uv run zensical build --strict` — no issues

Closes #99, closes #100, closes #105, closes #94, closes #77.
