### PR TITLE
Core unit-test coverage (GH-88) + GitHub Pages docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,74 @@
-name: Docs (migrated to Azure Pipelines)
+name: Documentation
+
+# Builds the Zensical docs site and publishes it to GitHub Pages
+# (https://amruthvvkp.github.io/flaui-uiautomation-wrapper/) on every push to master.
+#
+# The build mirrors the Azure Pipelines `docs_strict` job: uv-managed toolchain, the
+# `extract_versions.py` pre-step, and a strict Zensical build into `site/`. It runs on Linux
+# because mkdocstrings/Griffe analyses the source statically and does not import the
+# Windows-only FlaUI DLLs.
+#
+# NOTE: Repository Settings -> Pages -> "Build and deployment" -> Source must be set to
+# "GitHub Actions" for the deploy step to publish. This is mutually exclusive with the dormant,
+# branch-based `deploy_docs` stage in azure-pipelines.yml (gated off via PUBLISH_DOCS=false) —
+# keep deployment on exactly one of the two systems.
 
 on:
-    workflow_dispatch:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-    migrated:
-        runs-on: ubuntu-latest
-        steps:
-            - run: echo "Docs build and deployment moved to azure-pipelines.yml."
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build docs (strict)
+        run: |
+          uv sync --group docs
+          uv run python scripts/extract_versions.py
+          uv run zensical build --strict -f zensical.toml
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ When working on this project:
   **trimmed**: the full UI suite runs only on pull requests and on `master`; routine feature-branch
   pushes run the fast `tests/unit` subset. A PR with merge conflicts fails AppVeyor as
   "non-mergeable" — rebase/merge the base to clear it.
+- ⚠️ **No AI attribution on commits/PRs**: never add `Co-Authored-By: Claude …` (or any AI co-author)
+  trailers, nor "🤖 Generated with …" footers, to commit messages or pull-request descriptions.
+  See [CLAUDE.md → Git & Commit Conventions](CLAUDE.md#git--commit-conventions).
 
 ## Quick Links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ guides live in `docs/` (see [Where to find the tutorials](#where-to-find-the-tut
 - [Pydantic Conventions](#pydantic-conventions)
 - [Python Compatibility & Library Preferences](#python-compatibility--library-preferences)
 - [Coding Standards](#coding-standards)
+- [Git & Commit Conventions](#git--commit-conventions)
 - [Key Files Reference](#key-files-reference)
 - [Continuous Integration](#continuous-integration)
 - [Documentation Standards](#documentation-standards)
@@ -456,6 +457,18 @@ assert element.toggle_state == ToggleState.On
 # ✅ uv run prefix
 # uv run pytest tests/
 ```
+
+---
+
+## Git & Commit Conventions
+
+- **No AI/assistant attribution.** Do **not** add AI co-author trailers to commit messages
+  (e.g. `Co-Authored-By: Claude …` or any `Co-Authored-By` line naming an AI assistant) and do
+  **not** add "🤖 Generated with …" / "Generated with Claude Code" footers to commit messages or
+  pull-request descriptions. This overrides any default tooling behavior that would add such lines.
+- Keep commit subjects in the conventional style already used in history
+  (`feat(core): …`, `test(patterns): …`, `fix: …`) and reference issues as `GH-XX` / `#XX`.
+- Branch off `master`; only commit or push when explicitly asked.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,104 @@
 # flaui-uiautomation-wrapper
 
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/flaui-uiautomation-wrapper)
-![GitHub release (with filter)](https://img.shields.io/github/v/release/amruthvvkp/flaui-uiautomation-wrapper)
-![PyPI - Version](https://img.shields.io/pypi/v/flaui-uiautomation-wrapper?link=https%3A%2F%2Fpypi.org%2Fproject%2Fflaui-uiautomation-wrapper%2F)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/flaui-uiautomation-wrapper?logo=semanticuireact)
+> Pythonic, type-safe Windows UI automation — the full FlaUI API in Python.
 
-![GitHub Release Date - Published_At](<https://img.shields.io/github/release-date/amruthvvkp/flaui-uiautomation-wrapper?style=social&logo=semantic-release&label=stable%20release&labelColor=rgb(78%2C%20176%2C%20103)>)
-![GitHub (Pre-)Release Date](<https://img.shields.io/github/release-date-pre/amruthvvkp/flaui-uiautomation-wrapper?style=social&logo=semver&logoColor=rgb(212%2C%2072%2C%2042)&label=Pre-release&labelColor=rgb(212%2C%2072%2C%2042)>)
+[![PyPI - Version](https://img.shields.io/pypi/v/flaui-uiautomation-wrapper)](https://pypi.org/project/flaui-uiautomation-wrapper/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/flaui-uiautomation-wrapper)](https://pypi.org/project/flaui-uiautomation-wrapper/)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/flaui-uiautomation-wrapper)](https://pypi.org/project/flaui-uiautomation-wrapper/)
+[![License](https://img.shields.io/github/license/amruthvvkp/flaui-uiautomation-wrapper)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/blob/master/LICENSE)
 
-![GitHub milestones](https://img.shields.io/github/milestones/all/amruthvvkp/flaui-uiautomation-wrapper)
-![GitHub issues](https://img.shields.io/github/issues/amruthvvkp/flaui-uiautomation-wrapper)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/amruthvvkp/flaui-uiautomation-wrapper)
-![GitHub milestone details](https://img.shields.io/github/milestones/progress-percent/amruthvvkp/flaui-uiautomation-wrapper/1)
-
+[![Build Status](https://dev.azure.com/amruthvvkp/amruthvvkp/_apis/build/status%2Fflaui-uiautomation-wrapper-ci?branchName=master)](https://dev.azure.com/amruthvvkp/amruthvvkp/_build/latest?definitionId=1&branchName=master)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![Interrogate](badges/interrogate_badge.svg)
-[![Azure Pipelines](https://dev.azure.com/amruthvvkp/amruthvvkp/_apis/build/status/flaui-uiautomation-wrapper-ci?branchName=master)](https://dev.azure.com/amruthvvkp/amruthvvkp/_build/latest?definitionId=1&branchName=master)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/amruthvvkp/flaui-uiautomation-wrapper?branch=master&svg=true)](https://ci.appveyor.com/project/amruthvvkp/flaui-uiautomation-wrapper)
-![GitHub branch checks state](https://img.shields.io/github/checks-status/amruthvvkp/flaui-uiautomation-wrapper/master)
+[![Docs](https://img.shields.io/badge/docs-zensical-blue)](https://amruthvvkp.github.io/flaui-uiautomation-wrapper)
 
-[![GitHub contributors](https://img.shields.io/github/contributors/amruthvvkp/flaui-uiautomation-wrapper)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/graphs/contributors)
-![GitHub commits since latest release (by SemVer including pre-releases)](https://img.shields.io/github/commits-since/amruthvvkp/flaui-uiautomation-wrapper/latest/master)
-![GitHub last commit](https://img.shields.io/github/last-commit/amruthvvkp/flaui-uiautomation-wrapper)
-![GitHub](https://img.shields.io/github/license/amruthvvkp/flaui-uiautomation-wrapper)
-![PyPI - Format](https://img.shields.io/pypi/format/flaui-uiautomation-wrapper)
+[FlaUI](https://github.com/FlaUI/FlaUI) is a .NET library for UI automated testing of Windows
+desktop applications — Win32, WinForms, WPF, and Store apps — built on top of Microsoft's UI
+Automation technology. **flaui-uiautomation-wrapper** brings the complete FlaUI API to Python via
+[Python.NET](https://github.com/pythonnet/pythonnet), so you get the full power of FlaUI without
+leaving the Python ecosystem.
 
-[FlaUI](https://github.com/FlaUI/FlaUI#:~:text=FlaUI%20is%20a%20.,of%20a%20wrapper%20around%20them.) is a .NET library that can be used to perform UI automated testing of Windows desktop applications like Win32, WinForms, WPF, etc.. It is a wrapper that works alongside Windows inbuilt UI Automation technology to perform UI automation as required.
+Unlike existing Python integrations that are tied to a single test runner, this is a plug-and-play
+wrapper that works with **any** Python framework — [pytest](https://docs.pytest.org/),
+[Behave](https://behave.readthedocs.io/), [TestPlan](https://github.com/morganstanley/testplan),
+`unittest`, or your own tooling — with first-class IDE intellisense backed by Pydantic models.
 
-FlaUI has interesting approaches on multiple non-python projects. On python there is an integration with RobotFramework which allows tests to be written on [RobotFramework](https://github.com/GDATASoftwareAG/robotframework-flaui) and the keywords from it's plugin are utilized to identify elements by XPATH and perform UI actions.
+## Key Differentiators
 
-Other than RobotFramework-FLAUI, there are no Python libraries that help us leverage this useful C# library. The intend of this project is to make sure that a versatile and useful plug-and-play python wrapper is built which works well with IDE's intellisense, integrating with any Python frameworks like [PyTest](https://docs.pytest.org/en/7.1.x/), [Behave](https://behave.readthedocs.io/en/stable/), [TestPlan](https://github.com/morganstanley/testplan), etc. or any other tooling where UI automation is a necessary feature.
+- **Complete feature parity** — a 1:1 mapping of FlaUI's exposed C# API, not a thin subset.
+- **Type safety** — every input/output is backed by Pydantic models for validation and IDE
+  autocompletion.
+- **Any test framework** — pytest, unittest, Behave, TestPlan, or none at all.
+- **Pythonic API** — snake_case methods and Python-native types while preserving the C# structure.
 
-This project is in active development over the latest version of FlaUI (3.2.0) available on GitHub. New releases are expected to come by in the next few weeks and certainly the documentation would improve alongside the planned releases.
+## Installation
 
-If you would like to contribute or request a feature, feel free to join the discussions on the [project's GitHub page](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/discussions).
+Windows-only · Python 3.10–3.14. The required C# DLLs are bundled in the wheel — no separate driver
+binaries to manage.
 
-## Release Notes
+```bash
+pip install flaui-uiautomation-wrapper
+```
 
-Check out the release notes on [GitHub releases](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/releases).
+```bash
+uv add flaui-uiautomation-wrapper
+```
 
-## Project Roadmap
+## Quick start
 
-Check out the project roadmap on [GitHub milestones](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone)
+```python
+from flaui.lib.pythonnet_bridge import setup_pythonnet_bridge
 
-Active development is targetted towards the first major release of the project. The first major release is expected to be released by the end of 2023. The project roadmap is subject to change based on the project's progress.
+# MUST run before importing any C#-backed modules
+setup_pythonnet_bridge()
 
-You can track the project's progress on this [v1.0.0 roadmap](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/1) page.
+from flaui.lib.enums import UIAutomationTypes
+from flaui.modules.automation import Automation
+
+automation = Automation(UIAutomationTypes.UIA3)
+main_window = automation.application.launch("notepad.exe").get_main_window(automation)
+main_window.find_first_by_x_path("//Button[@Name='OK']").as_button().invoke()
+```
+
+## Documentation
+
+Full documentation lives at
+**[amruthvvkp.github.io/flaui-uiautomation-wrapper](https://amruthvvkp.github.io/flaui-uiautomation-wrapper)**,
+including:
+
+- **Basics & Advanced** guides (Initialize → Launch → Find → Interact, XPath, ConditionFactory,
+  caching) with side-by-side Python/C# examples.
+- **API Reference** auto-generated for every control and pattern.
+- **Examples** for pytest, unittest, Behave, TestPlan, and Robot Framework.
+- **Contributing** guides for development, testing, and porting C# tests.
+
+## Roadmap
+
+This project is in active development toward its first major release. Track progress on the
+[v1.0.0 milestone](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/1) and the
+full [`ROADMAP.md`](ROADMAP.md), which also outlines post-v1 companion tooling (a record-and-generate
+recorder, an MCP server, a `pytest-flaui` plugin, and FlaUI agent skills).
+
+Have an idea or feature request? Join the
+[GitHub Discussions](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/discussions).
+
+## Inspirations & Credits
+
+- **[FlaUI](https://github.com/FlaUI/FlaUI)** — the C# library this project wraps; its core logic and
+  test applications are the foundation of this wrapper.
+- **[robotframework-flaui](https://github.com/GDATASoftwareAG/robotframework-flaui)** (GDATA) — the
+  prior-art Python integration for FlaUI that influenced this project's direction.
+- **[Python.NET](https://github.com/pythonnet/pythonnet)** — the interop bridge that makes calling
+  FlaUI from Python possible.
+- **[Playwright](https://playwright.dev/python/)** / **[`pytest-playwright`](https://github.com/microsoft/playwright-pytest)**
+  and **[FlaUIRecorder](https://github.com/twenzel/FlaUIRecorder)** — inspirations for the planned
+  recorder and pytest tooling.
+
+## Contributing
+
+Contributions are welcome! See [docs/contributing.md](docs/contributing.md) for the development
+workflow, coding standards, and testing guidelines.
+
+## License
+
+Licensed under the [LGPL-3.0-or-later](LICENSE).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,13 +118,56 @@ areas (capturing, overlay, video, logging) are **in scope for v1.0**.
   **[#66](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/66)** · then
   **[#84](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/84) v1.0.0 release**.
 
-### Post-v1 (out of scope)
+### Post-v1 — parity gaps & deferred tests (out of scope for v1.0)
 - **[#121](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/121)** — CustomNavigation
   pattern (absent from FlaUI.Core; lives only in raw COM interop).
 - **Touch input tests** — `TouchTests.cs` is `[Ignore]`d upstream (unreliable on most CI/hardware).
 - **Full app integration suites** (Calculator / Notepad / Paint end-to-end) — deferred under #88/#89;
   UI varies by Windows version/language. A `tests/integration/` skeleton (marked
   `@pytest.mark.integration`, skipped by default) is the intended home.
+
+---
+
+## Post-v1 — companion tooling & ecosystem
+
+> These items start **only after v1.0 ships** (the v1 gate above takes priority). Each is intended
+> as a **separate, independently versioned companion PyPI package** so the core
+> `flaui-uiautomation-wrapper` stays lean — mirroring how `pytest-playwright` ships alongside
+> `playwright`. The core wrapper remains the single dependency they all build on.
+
+| Package / effort | What it is | Inspiration |
+|------------------|------------|-------------|
+| **FlaUI agent skills** | Claude Code skills bundle for FlaUI development | — |
+| **`flaui-recorder`** | Record-and-generate UI script tool | [twenzel/FlaUIRecorder](https://github.com/twenzel/FlaUIRecorder), Playwright codegen |
+| **`flaui-mcp`** | MCP server exposing FlaUI automation as tools | [shanselman/FlaUI-MCP](https://github.com/shanselman/FlaUI-MCP) |
+| **`pytest-flaui`** | pytest plugin: fixtures + recorder + capture-on-failure | [`pytest-playwright`](https://github.com/microsoft/playwright-pytest) |
+
+### FlaUI agent skills
+A bundle of Claude Code skills (`.claude/skills/…`) packaging FlaUI development knowledge so users
+building automation get assisted workflows: element/pattern lookup, test scaffolding, and C#→Python
+test-porting helpers. Distributable as an installable skills bundle.
+
+### `flaui-recorder`
+A Playwright-codegen-style **record-and-generate** tool: watch a user's interactions against a live
+Windows app (via UIA events / hit-testing) and emit ready-to-run Python FlaUI scripts. Lowers the
+barrier to authoring automation by hand. Builds on this wrapper's event handlers and XPath navigator;
+inspired by the C# [twenzel/FlaUIRecorder](https://github.com/twenzel/FlaUIRecorder).
+
+### `flaui-mcp`
+An **MCP server** exposing FlaUI Python automation as callable tools so agents/LLMs can drive Windows
+desktop apps — the Python counterpart to the C#
+[shanselman/FlaUI-MCP](https://github.com/shanselman/FlaUI-MCP).
+
+### `pytest-flaui`
+A **pytest plugin** modeled on `pytest-playwright`: ready-made `automation` / session fixtures, the
+UIA2×UIA3 matrix helpers this repo already uses, screenshots/video on failure via
+[`flaui/core/capturing.py`](flaui/core/capturing.py), and `flaui-recorder` integration for codegen.
+
+### Docs — broaden Python/C# tabbed examples *(enhancement, not net-new infra)*
+Side-by-side Python/C# tabs already exist (`pymdownx.tabbed` in `docs/index.md`, `docs/basics.md`,
+`docs/advanced.md`). Post-v1 scope is **expanding** C#-parity tabs across the remaining guide and API
+pages — valuable because FlaUI's own documentation is sparse, so these become a reference for both
+audiences.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,9 +53,12 @@ FlaUI provides a modern, clean, and typed API for automating Windows application
 
 --8<-- "docs/_includes/flaui_versions.md"
 
-## Credits
+## Inspirations & Credits
 
 - **[FlaUI](https://github.com/FlaUI/FlaUI)**: The core logic and test applications are derived from the upstream C# project.
+- **[robotframework-flaui](https://github.com/GDATASoftwareAG/robotframework-flaui)** (GDATA): The prior-art Python integration for FlaUI that influenced this project's direction.
+- **[Python.NET](https://github.com/pythonnet/pythonnet)**: The interop bridge that makes calling FlaUI from Python possible.
+- **[Playwright](https://playwright.dev/python/) / [`pytest-playwright`](https://github.com/microsoft/playwright-pytest)** and **[FlaUIRecorder](https://github.com/twenzel/FlaUIRecorder)**: Inspirations for the planned recorder and pytest tooling.
 - **Community**: Special thanks to the contributors of FlaUI and the Python.NET team.
 
 ## Next Steps

--- a/flaui/core/condition_factory.py
+++ b/flaui/core/condition_factory.py
@@ -52,19 +52,20 @@ class PropertyCondition(BaseModel):
         :param value: Value to compare
         :return: True/False
         """
-        return self.cs_condition.Equals(value.cs_condition.cs_condition)
+        other = value.cs_condition if isinstance(value, PropertyCondition) else value
+        return self.cs_condition.Equals(other)
 
     def Not(self, new_condition: PropertyCondition) -> PropertyCondition:
-        """Adds the given condition with an "not".
+        """Combines this condition with the negation of another ("and not").
 
-        :param new_condition: New condition
-        :return: PropertyCondition
+        The C# ``ConditionBase.Not()`` is parameterless and negates the condition it is called on,
+        so this builds ``self AND NOT new_condition``.
+
+        :param new_condition: Condition to negate and combine with this one.
+        :return: PropertyCondition matching this condition and NOT ``new_condition``.
         """
-        return PropertyCondition(
-            cs_condition=self.cs_condition.Not(
-                new_condition.cs_condition if isinstance(new_condition, PropertyCondition) else new_condition
-            )
-        )
+        other = new_condition.cs_condition if isinstance(new_condition, PropertyCondition) else new_condition
+        return PropertyCondition(cs_condition=self.cs_condition.And(other.Not()))
 
     def Or(self, new_condition: PropertyCondition) -> PropertyCondition:
         """Packs this condition into a not condition.
@@ -224,7 +225,7 @@ class ConditionFactory(BaseModel):
         """
         return PropertyCondition(
             cs_condition=self.raw_cf.ByLocalizedControlType(
-                localized_control_type, condition_flags_property_condition_flags
+                localized_control_type, condition_flags_property_condition_flags.value
             )
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 
+[project.urls]
+Homepage = "https://amruthvvkp.github.io/flaui-uiautomation-wrapper"
+Documentation = "https://amruthvvkp.github.io/flaui-uiautomation-wrapper"
+Repository = "https://github.com/amruthvvkp/flaui-uiautomation-wrapper"
+Issues = "https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues"
+Changelog = "https://github.com/amruthvvkp/flaui-uiautomation-wrapper/releases"
+
 [dependency-groups]
 dev = [
     "interrogate>=1.7.0",

--- a/tests/unit/core/test_automation_base.py
+++ b/tests/unit/core/test_automation_base.py
@@ -1,0 +1,244 @@
+"""Unit tests for the :class:`flaui.core.automation_base.AutomationBase` facade methods (GH-88).
+
+Complements ``test_automation_base_wrappers.py`` (which covers the UIA2/UIA3 subtype wiring) by
+exercising the property accessors, element factories, event registration, ``compare`` and the
+``wrap_cs_automation`` fallback/error branches. A real UIA3 engine is used where a live automation
+object is needed; small fakes drive the ``wrap_cs_automation`` branches that real C# instances can
+never reach (they are caught by the ``isinstance`` checks first).
+"""
+
+import ctypes
+from typing import Generator
+from unittest.mock import MagicMock
+
+from System import TimeSpan  # type: ignore
+from System.Drawing import Point as CSPoint  # type: ignore
+from pydantic import ValidationError
+import pytest
+
+from flaui.core.automation_base import AutomationBase, wrap_cs_automation
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.condition_factory import ConditionFactory
+from flaui.core.event_handlers import EventRegistration
+from flaui.core.overlay import OverlayManager
+from flaui.lib.system.drawing import Point
+from flaui.uia3 import UIA3Automation
+
+
+@pytest.fixture(scope="module")
+def engine() -> Generator[UIA3Automation, None, None]:
+    """Yield a real UIA3 automation engine, disposing it afterwards."""
+    automation = UIA3Automation()
+    try:
+        yield automation
+    finally:
+        automation.dispose()
+
+
+class TestValidation:
+    """Validate the constructor guard."""
+
+    def test_none_raw_automation_rejected(self) -> None:
+        """Constructing the base with ``raw_automation=None`` raises a validation error."""
+        with pytest.raises(ValidationError):
+            AutomationBase(raw_automation=None)
+
+
+class TestLibraryProperties:
+    """Validate the identifier-library and factory accessors."""
+
+    def test_libraries_present(self, engine: UIA3Automation) -> None:
+        """All four identifier libraries are exposed."""
+        assert engine.property_library is not None
+        assert engine.event_library is not None
+        assert engine.pattern_library is not None
+        assert engine.text_attribute_library is not None
+
+    def test_condition_factory(self, engine: UIA3Automation) -> None:
+        """``condition_factory`` returns a Python :class:`ConditionFactory`."""
+        assert isinstance(engine.condition_factory, ConditionFactory)
+
+    def test_overlay_manager(self, engine: UIA3Automation) -> None:
+        """``overlay_manager`` returns a Python :class:`OverlayManager`."""
+        assert isinstance(engine.overlay_manager, OverlayManager)
+
+    def test_tree_walker_factory(self, engine: UIA3Automation) -> None:
+        """``tree_walker_factory`` exposes the C# factory."""
+        assert engine.tree_walker_factory is not None
+
+    def test_sentinel_values(self, engine: UIA3Automation) -> None:
+        """The not-supported and mixed-attribute sentinels are accessible."""
+        # These are provider sentinels; we only assert they can be read without error.
+        _ = engine.not_supported_value
+        _ = engine.mixed_attribute_value
+
+
+class TestTimeoutAndBehaviorProperties:
+    """Validate the get/set round-trips on the timeout and behavior properties."""
+
+    def test_transaction_timeout_round_trip(self, engine: UIA3Automation) -> None:
+        """``transaction_timeout`` is readable and settable."""
+        original = engine.transaction_timeout
+        engine.transaction_timeout = TimeSpan.FromSeconds(30)
+        assert engine.transaction_timeout == TimeSpan.FromSeconds(30)
+        engine.transaction_timeout = original
+
+    def test_connection_timeout_round_trip(self, engine: UIA3Automation) -> None:
+        """``connection_timeout`` is readable and settable."""
+        original = engine.connection_timeout
+        engine.connection_timeout = TimeSpan.FromSeconds(5)
+        assert engine.connection_timeout == TimeSpan.FromSeconds(5)
+        engine.connection_timeout = original
+
+    def test_connection_recovery_behavior_round_trip(self, engine: UIA3Automation) -> None:
+        """``connection_recovery_behavior`` is readable and settable."""
+        original = engine.connection_recovery_behavior
+        engine.connection_recovery_behavior = original
+        assert engine.connection_recovery_behavior == original
+
+    def test_coalesce_events_round_trip(self, engine: UIA3Automation) -> None:
+        """``coalesce_events`` is readable and settable."""
+        original = engine.coalesce_events
+        engine.coalesce_events = original
+        assert engine.coalesce_events == original
+
+
+class TestElementFactories:
+    """Validate the methods that produce :class:`AutomationElement` instances."""
+
+    def test_from_point(self, engine: UIA3Automation) -> None:
+        """``from_point`` returns the element at a screen coordinate."""
+        element = engine.from_point(Point(raw_value=CSPoint(0, 0)))
+        assert isinstance(element, AutomationElement)
+
+    def test_from_handle(self, engine: UIA3Automation) -> None:
+        """``from_handle`` returns the element for a window handle."""
+        desktop_hwnd = ctypes.windll.user32.GetDesktopWindow()
+        element = engine.from_handle(int(desktop_hwnd))
+        assert isinstance(element, AutomationElement)
+
+    def test_focused_element(self, engine: UIA3Automation) -> None:
+        """``focused_element`` returns an element or ``None``."""
+        focused = engine.focused_element()
+        assert focused is None or isinstance(focused, AutomationElement)
+
+    def test_focused_element_none_when_no_focus(self) -> None:
+        """``focused_element`` returns ``None`` when the provider reports no focused element."""
+        base = AutomationBase(raw_automation=MagicMock(**{"FocusedElement.return_value": None}))
+        assert base.focused_element() is None
+
+
+class TestToCsAutomationElement:
+    """Validate the static element-unwrapping helper."""
+
+    def test_none_returns_none(self) -> None:
+        """``None`` maps to ``None``."""
+        assert AutomationBase._to_cs_automation_element(None) is None
+
+    def test_python_element_unwrapped(self, engine: UIA3Automation) -> None:
+        """A Python :class:`AutomationElement` is unwrapped to its raw C# element."""
+        desktop = engine.get_desktop()
+        assert AutomationBase._to_cs_automation_element(desktop) is desktop.raw_element
+
+    def test_raw_value_passthrough(self) -> None:
+        """An object without ``raw_element`` passes through unchanged."""
+        sentinel = object()
+        assert AutomationBase._to_cs_automation_element(sentinel) is sentinel
+
+
+class TestCompare:
+    """Validate element identity comparison."""
+
+    def test_compare_same_element(self, engine: UIA3Automation) -> None:
+        """An element compares equal to itself."""
+        desktop = engine.get_desktop()
+        assert engine.compare(desktop, desktop) is True
+
+
+class TestFocusChangedEvents:
+    """Validate focus-changed registration and both unregister paths."""
+
+    def test_register_then_unregister_via_registration(self, engine: UIA3Automation) -> None:
+        """Registering returns an :class:`EventRegistration`; unregistering it deactivates it."""
+        registration = engine.register_focus_changed_event(lambda _element: None)
+        assert isinstance(registration, EventRegistration)
+        assert registration.is_active is True
+
+        engine.unregister_focus_changed_event(registration)
+        assert registration.is_active is False
+
+    def test_unregister_via_raw_handler(self, engine: UIA3Automation) -> None:
+        """Passing a raw C# handler takes the non-registration unregister path."""
+        registration = engine.register_focus_changed_event(lambda _element: None)
+        # Pass the raw handler (not the EventRegistration) to exercise the else-branch.
+        engine.unregister_focus_changed_event(registration.raw_handler)
+
+    def test_unregister_all_events(self, engine: UIA3Automation) -> None:
+        """``unregister_all_events`` runs without error."""
+        engine.register_focus_changed_event(lambda _element: None)
+        engine.unregister_all_events()
+
+
+class TestWrapCsAutomationBranches:
+    """Validate the ``wrap_cs_automation`` fallback and error branches."""
+
+    def test_none_raises_value_error(self) -> None:
+        """A ``None`` automation reference raises ``ValueError``."""
+        with pytest.raises(ValueError):
+            wrap_cs_automation(None)
+
+    def test_fallback_label_uia3(self) -> None:
+        """A non-C#-instance object reporting ``AutomationType == 'UIA3'`` wraps as UIA3."""
+
+        class _FakeUia3:
+            """Stand-in object that reports a UIA3 automation type."""
+
+            class AutomationType:
+                """Fake automation-type enum with a ToString."""
+
+                @staticmethod
+                def ToString() -> str:
+                    """Return the UIA3 label."""
+                    return "UIA3"
+
+        wrapped = wrap_cs_automation(_FakeUia3())
+        assert isinstance(wrapped, UIA3Automation)
+
+    def test_fallback_label_uia2(self) -> None:
+        """A non-C#-instance object reporting ``AutomationType == 'UIA2'`` wraps as UIA2."""
+        from flaui.uia2 import UIA2Automation
+
+        class _FakeUia2:
+            """Stand-in object that reports a UIA2 automation type."""
+
+            class AutomationType:
+                """Fake automation-type enum with a ToString."""
+
+                @staticmethod
+                def ToString() -> str:
+                    """Return the UIA2 label."""
+                    return "UIA2"
+
+        assert isinstance(wrap_cs_automation(_FakeUia2()), UIA2Automation)
+
+    def test_unsupported_object_raises_type_error(self) -> None:
+        """An object whose ``AutomationType`` access fails raises ``TypeError``."""
+        with pytest.raises(TypeError):
+            wrap_cs_automation(object())
+
+    def test_unknown_label_raises_type_error(self) -> None:
+        """A recognised-shape object with an unknown label raises ``TypeError``."""
+
+        class _FakeUnknown:
+            """Stand-in object that reports an unrecognised automation type."""
+
+            class AutomationType:
+                """Fake automation-type enum with a ToString."""
+
+                @staticmethod
+                def ToString() -> str:
+                    """Return an unsupported label."""
+                    return "UIA4"
+
+        with pytest.raises(TypeError):
+            wrap_cs_automation(_FakeUnknown())

--- a/tests/unit/core/test_cache_request.py
+++ b/tests/unit/core/test_cache_request.py
@@ -1,0 +1,110 @@
+"""Unit tests for the :class:`flaui.core.cache_request.CacheRequest` wrapper."""
+
+from FlaUI.Core import CacheRequest as CSCacheRequest  # type: ignore
+from FlaUI.Core.Identifiers import PatternId, PropertyId  # type: ignore
+
+from flaui.core.cache_request import CacheRequest
+from flaui.core.definitions import AutomationElementMode, TreeScope
+from flaui.lib.enums import UIAutomationTypes
+from flaui.modules.automation import Automation
+
+
+class TestConstruction:
+    """Validate the three construction paths of ``CacheRequest.__init__``."""
+
+    def test_default_construction(self) -> None:
+        """Passing nothing builds a fresh C# ``CacheRequest``."""
+        cache_request = CacheRequest()
+
+        assert isinstance(cache_request._cs_instance, CSCacheRequest)
+
+    def test_wraps_existing_cs_instance(self) -> None:
+        """An existing C# instance is stored as-is."""
+        cs_instance = CSCacheRequest()
+
+        assert CacheRequest(_cs_instance=cs_instance)._cs_instance is cs_instance
+
+    def test_construct_from_automation(self) -> None:
+        """An ``Automation`` wrapper falls back to a default C# ``CacheRequest``."""
+        automation = Automation(UIAutomationTypes.UIA3)
+        try:
+            cache_request = CacheRequest(_cs_instance=automation)
+            assert isinstance(cache_request._cs_instance, CSCacheRequest)
+        finally:
+            automation.cs_automation.Dispose()
+
+
+class TestProperties:
+    """Validate the property getters/setters round-trip through the C# instance."""
+
+    def test_automation_element_mode_enum_and_raw(self) -> None:
+        """The mode is settable via the Python enum and via a raw C# value."""
+        cache_request = CacheRequest()
+
+        cache_request.automation_element_mode = AutomationElementMode.Full
+        full = cache_request.automation_element_mode
+        cache_request.automation_element_mode = AutomationElementMode.None_
+        assert cache_request.automation_element_mode != full
+
+        # Assigning a non-enum (raw C#) value hits the pass-through branch.
+        cache_request.automation_element_mode = full
+        assert cache_request.automation_element_mode == full
+
+    def test_tree_scope(self) -> None:
+        """Tree scope is settable via the Python enum."""
+        cache_request = CacheRequest()
+
+        cache_request.tree_scope = TreeScope.Subtree
+        assert cache_request.tree_scope is not None
+
+    def test_tree_filter_roundtrip(self) -> None:
+        """The default tree filter is readable and re-assignable."""
+        cache_request = CacheRequest()
+
+        default = cache_request.tree_filter
+        assert default is not None
+        cache_request.tree_filter = default
+
+    def test_patterns_and_properties(self) -> None:
+        """Added patterns/properties are reflected by the collection accessors."""
+        cache_request = CacheRequest()
+
+        cache_request.add_property(PropertyId(30005, "Name"))
+        cache_request.add_pattern(PatternId(10000, "TestPattern", None))
+
+        assert cache_request.properties is not None
+        assert cache_request.patterns is not None
+
+
+class TestCachingLifecycle:
+    """Validate activation, the active-state query, and the static stack helpers."""
+
+    def test_activate_toggles_caching_state(self) -> None:
+        """``activate`` enables caching for the duration of the block."""
+        cache_request = CacheRequest()
+
+        assert CacheRequest.is_caching_active() is False
+        with cache_request.activate():
+            assert CacheRequest.is_caching_active() is True
+            assert isinstance(CacheRequest.current(), CacheRequest)
+        assert CacheRequest.is_caching_active() is False
+
+    def test_current_outside_activation(self) -> None:
+        """``current`` is ``None`` (or a wrapper) when no request is active."""
+        current = CacheRequest.current()
+
+        assert current is None or isinstance(current, CacheRequest)
+
+    def test_push_and_pop(self) -> None:
+        """A request can be pushed onto and popped from the static stack."""
+        cache_request = CacheRequest()
+
+        CacheRequest.push(cache_request)
+        CacheRequest.pop()
+
+    def test_force_no_cache(self) -> None:
+        """``force_no_cache`` returns a disposable that suppresses caching."""
+        disposable = CacheRequest.force_no_cache()
+
+        assert disposable is not None
+        disposable.Dispose()

--- a/tests/unit/core/test_capturing.py
+++ b/tests/unit/core/test_capturing.py
@@ -1,10 +1,39 @@
 """Unit tests for the capturing/video wrappers (GH-95).
 
-Settings objects and enums only need the PythonNet bridge (set up by the global conftest); live
-screen capture is exercised in the UI suite.
+Settings objects and enums only need the PythonNet bridge (set up by the global conftest). Real
+screen/element captures are cheap and run here too; only ``VideoRecorder.start`` /
+``download_ffmpeg`` (which need ffmpeg or network access) are deferred to the UI suite.
 """
 
-from flaui.core.capturing import CaptureSettings, VideoFormat, VideoRecorderSettings
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock
+
+from System.Drawing import Rectangle as CSRectangle  # type: ignore
+import pytest
+
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.capturing import (
+    Capture,
+    CaptureImage,
+    CaptureSettings,
+    VideoFormat,
+    VideoRecorder,
+    VideoRecorderSettings,
+)
+from flaui.lib.enums import UIAutomationTypes
+from flaui.lib.system.drawing import Rectangle
+from flaui.modules.automation import Automation
+
+
+@pytest.fixture(scope="module")
+def desktop() -> Generator[AutomationElement, None, None]:
+    """Yield the desktop element from a UIA3 automation, disposing it afterwards."""
+    automation = Automation(UIAutomationTypes.UIA3)
+    try:
+        yield automation.automation_base.get_desktop()
+    finally:
+        automation.cs_automation.Dispose()
 
 
 class TestCaptureSettings:
@@ -59,3 +88,106 @@ class TestVideoRecorderSettings:
         assert cs.TargetVideoPath == "out.mp4"
         assert cs.VideoQuality == 5
         assert str(cs.VideoFormat) == "xvid"
+
+    def test_cs_object_skips_unset_optional_paths(self) -> None:
+        """With ``ffmpeg_path``/``target_video_path`` unset, ``cs_object`` leaves the C# defaults."""
+        cs = VideoRecorderSettings().cs_object
+        assert cs.FrameRate == 5
+        assert cs.UseCompressedImages is True
+
+
+class TestCaptureImage:
+    """Tests for :class:`CaptureImage`, driven by a real primary-screen capture."""
+
+    def test_properties(self) -> None:
+        """``bitmap`` and ``original_bounds`` expose the native image data."""
+        with Capture.main_screen() as image:
+            assert image.bitmap is not None
+            assert isinstance(image.original_bounds, Rectangle)
+
+    def test_to_file_writes_image(self, tmp_path: Path) -> None:
+        """``to_file`` persists the image to disk."""
+        destination = tmp_path / "capture.png"
+        with Capture.main_screen() as image:
+            image.to_file(str(destination))
+        assert destination.exists() and destination.stat().st_size > 0
+
+    def test_apply_overlays_returns_self(self) -> None:
+        """``apply_overlays`` with no overlays is a no-op that returns the image for chaining."""
+        with Capture.main_screen() as image:
+            assert image.apply_overlays() is image
+
+    def test_context_manager_returns_self_and_disposes(self) -> None:
+        """The context manager yields the same image and disposes it on exit without error."""
+        image = Capture.main_screen()
+        with image as entered:
+            assert entered is image
+
+
+class TestCaptureStatics:
+    """Tests for the :class:`Capture` static helpers using real captures."""
+
+    def test_main_screen_with_and_without_settings(self) -> None:
+        """``main_screen`` works with default and explicit settings (covers both ``_cs_settings`` paths)."""
+        with Capture.main_screen() as plain:
+            assert isinstance(plain, CaptureImage)
+        with Capture.main_screen(CaptureSettings(output_scale=0.5)) as scaled:
+            assert isinstance(scaled, CaptureImage)
+
+    def test_screen(self) -> None:
+        """``screen`` captures the whole virtual desktop when the index is out of range."""
+        with Capture.screen(-1) as image:
+            assert isinstance(image, CaptureImage)
+
+    def test_rectangle(self) -> None:
+        """``rectangle`` captures a desktop-relative region."""
+        with Capture.rectangle(Rectangle(raw_value=CSRectangle(0, 0, 40, 40))) as image:
+            assert isinstance(image, CaptureImage)
+
+    def test_element(self, desktop: AutomationElement) -> None:
+        """``element`` captures a single automation element."""
+        with Capture.element(desktop) as image:
+            assert isinstance(image, CaptureImage)
+
+    def test_element_rectangle(self, desktop: AutomationElement) -> None:
+        """``element_rectangle`` captures a region relative to an element."""
+        with Capture.element_rectangle(desktop, Rectangle(raw_value=CSRectangle(0, 0, 10, 10))) as image:
+            assert isinstance(image, CaptureImage)
+
+    def test_screens_with_element(self, desktop: AutomationElement) -> None:
+        """``screens_with_element`` captures every screen the element overlaps."""
+        with Capture.screens_with_element(desktop) as image:
+            assert isinstance(image, CaptureImage)
+
+
+class TestVideoRecorder:
+    """Tests for :class:`VideoRecorder` lifecycle, driven by a stub C# recorder.
+
+    ``start`` and ``download_ffmpeg`` require ffmpeg/network and are covered by the UI suite.
+    """
+
+    def test_target_video_path(self) -> None:
+        """``target_video_path`` forwards to the native recorder."""
+        raw = MagicMock()
+        raw.TargetVideoPath = "out.mp4"
+        assert VideoRecorder(raw_recorder=raw).target_video_path == "out.mp4"
+
+    def test_stop(self) -> None:
+        """``stop`` calls the native ``Stop``."""
+        raw = MagicMock()
+        VideoRecorder(raw_recorder=raw).stop()
+        raw.Stop.assert_called_once_with()
+
+    def test_dispose(self) -> None:
+        """``dispose`` calls the native ``Dispose``."""
+        raw = MagicMock()
+        VideoRecorder(raw_recorder=raw).dispose()
+        raw.Dispose.assert_called_once_with()
+
+    def test_context_manager_disposes(self) -> None:
+        """The context manager returns the recorder and disposes it on exit."""
+        raw = MagicMock()
+        recorder = VideoRecorder(raw_recorder=raw)
+        with recorder as entered:
+            assert entered is recorder
+        raw.Dispose.assert_called_once_with()

--- a/tests/unit/core/test_condition_factory.py
+++ b/tests/unit/core/test_condition_factory.py
@@ -1,0 +1,147 @@
+"""Unit tests for :mod:`flaui.core.condition_factory` (GH-88).
+
+``ConditionFactory`` and ``PropertyCondition`` delegate to real C# condition objects, and
+``PropertyCondition.cs_condition`` is type-validated against the C# condition types — so a mock will
+not pass validation. These tests therefore drive a real ``ConditionFactory`` obtained from a UIA3
+automation (no running application required).
+
+They also lock in the fixes for three previously broken methods: ``Not`` (and-not semantics),
+``Equals`` (condition equality), and ``by_localized_control_type``.
+"""
+
+from typing import Generator
+
+import pytest
+
+from flaui.core.condition_factory import ConditionFactory, PropertyCondition
+from flaui.core.definitions import ControlType, PropertyConditionFlags
+from flaui.core.framework_types import FrameworkType
+from flaui.lib.enums import KnownClassNames, UIAutomationTypes
+from flaui.modules.automation import Automation
+
+
+@pytest.fixture(scope="module")
+def condition_factory() -> Generator[ConditionFactory, None, None]:
+    """Yield a real :class:`ConditionFactory` from a UIA3 automation, disposing it afterwards."""
+    automation = Automation(UIAutomationTypes.UIA3)
+    try:
+        yield automation.cf
+    finally:
+        automation.cs_automation.Dispose()
+
+
+class TestConditionFactoryBuilders:
+    """Validate every ``ConditionFactory`` builder returns a populated :class:`PropertyCondition`."""
+
+    def test_by_automation_id(self, condition_factory: ConditionFactory) -> None:
+        """``by_automation_id`` builds a condition on the AutomationId property."""
+        condition = condition_factory.by_automation_id("save-button")
+        assert isinstance(condition, PropertyCondition)
+        assert condition.cs_condition is not None
+
+    def test_by_control_type(self, condition_factory: ConditionFactory) -> None:
+        """``by_control_type`` builds a condition on the ControlType property."""
+        assert isinstance(condition_factory.by_control_type(ControlType.Button), PropertyCondition)
+
+    def test_by_class_name_str_and_enum(self, condition_factory: ConditionFactory) -> None:
+        """``by_class_name`` accepts both a plain string and a :class:`KnownClassNames` member."""
+        assert isinstance(condition_factory.by_class_name("TextBox"), PropertyCondition)
+        known = next(iter(KnownClassNames))
+        assert isinstance(condition_factory.by_class_name(known), PropertyCondition)
+
+    def test_by_name(self, condition_factory: ConditionFactory) -> None:
+        """``by_name`` builds a condition on the Name property."""
+        assert isinstance(condition_factory.by_name("OK"), PropertyCondition)
+
+    def test_by_text(self, condition_factory: ConditionFactory) -> None:
+        """``by_text`` builds a condition on the text value."""
+        assert isinstance(condition_factory.by_text("Submit"), PropertyCondition)
+
+    def test_by_framework_id(self, condition_factory: ConditionFactory) -> None:
+        """``by_framework_id`` builds a condition on the FrameworkId property."""
+        assert isinstance(condition_factory.by_framework_id("WPF"), PropertyCondition)
+
+    def test_by_framework_type(self, condition_factory: ConditionFactory) -> None:
+        """``by_framework_type`` builds a condition on the framework type."""
+        framework_type = next(ft for ft in FrameworkType if ft.value is not None)
+        assert isinstance(condition_factory.by_framework_type(framework_type), PropertyCondition)
+
+    def test_by_process_id(self, condition_factory: ConditionFactory) -> None:
+        """``by_process_id`` builds a condition on the process id."""
+        assert isinstance(condition_factory.by_process_id(1234), PropertyCondition)
+
+    def test_by_localized_control_type(self, condition_factory: ConditionFactory) -> None:
+        """``by_localized_control_type`` builds a condition (regression: previously passed the enum)."""
+        assert isinstance(condition_factory.by_localized_control_type("button"), PropertyCondition)
+
+    def test_by_help_text(self, condition_factory: ConditionFactory) -> None:
+        """``by_help_text`` builds a condition on the help text."""
+        assert isinstance(condition_factory.by_help_text("tooltip"), PropertyCondition)
+
+    def test_by_value(self, condition_factory: ConditionFactory) -> None:
+        """``by_value`` builds a condition on the value."""
+        assert isinstance(condition_factory.by_value("42"), PropertyCondition)
+
+    def test_menu(self, condition_factory: ConditionFactory) -> None:
+        """``menu`` builds a Menu/MenuBar condition."""
+        assert isinstance(condition_factory.menu(), PropertyCondition)
+
+    def test_grid(self, condition_factory: ConditionFactory) -> None:
+        """``grid`` builds a DataGrid/List condition."""
+        assert isinstance(condition_factory.grid(), PropertyCondition)
+
+    def test_scroll_bars(self, condition_factory: ConditionFactory) -> None:
+        """The scrollbar helpers build their respective conditions."""
+        assert isinstance(condition_factory.horizontal_scroll_bar(), PropertyCondition)
+        assert isinstance(condition_factory.vertical_scroll_bar(), PropertyCondition)
+
+
+class TestPropertyCondition:
+    """Validate the combinators and accessors on :class:`PropertyCondition`."""
+
+    @pytest.fixture()
+    def conditions(self, condition_factory: ConditionFactory) -> tuple[PropertyCondition, PropertyCondition]:
+        """Return two distinct conditions to combine."""
+        return condition_factory.by_name("OK"), condition_factory.by_automation_id("btn1")
+
+    def test_and_wrapper_and_raw(self, conditions: tuple[PropertyCondition, PropertyCondition]) -> None:
+        """``And`` accepts both a :class:`PropertyCondition` and a raw C# condition."""
+        first, second = conditions
+        assert isinstance(first.And(second), PropertyCondition)
+        assert isinstance(first.And(second.cs_condition), PropertyCondition)
+
+    def test_or_wrapper_and_raw(self, conditions: tuple[PropertyCondition, PropertyCondition]) -> None:
+        """``Or`` accepts both a :class:`PropertyCondition` and a raw C# condition."""
+        first, second = conditions
+        assert isinstance(first.Or(second), PropertyCondition)
+        assert isinstance(first.Or(second.cs_condition), PropertyCondition)
+
+    def test_not_builds_and_not(self, conditions: tuple[PropertyCondition, PropertyCondition]) -> None:
+        """``Not`` builds ``self AND NOT other`` (regression: previously raised ``TypeError``)."""
+        first, second = conditions
+        combined = first.Not(second)
+        assert isinstance(combined, PropertyCondition)
+        rendered = combined.ToString()
+        assert "AND NOT" in rendered
+
+    def test_not_accepts_raw_condition(self, conditions: tuple[PropertyCondition, PropertyCondition]) -> None:
+        """``Not`` also accepts a raw C# condition for the negated operand."""
+        first, second = conditions
+        assert isinstance(first.Not(second.cs_condition), PropertyCondition)
+
+    def test_equals(self, conditions: tuple[PropertyCondition, PropertyCondition]) -> None:
+        """``Equals`` compares condition equality (regression: previously raised ``AttributeError``)."""
+        first, second = conditions
+        assert first.Equals(first) is True
+        assert first.Equals(second) is False
+
+    def test_property_value_and_flags(self, condition_factory: ConditionFactory) -> None:
+        """``Property``, ``Value`` and ``PropertyConditionFlags`` expose the underlying condition data."""
+        condition = condition_factory.by_name("OK")
+        assert condition.Property is not None
+        assert condition.Value == "OK"
+        assert isinstance(condition.PropertyConditionFlags, PropertyConditionFlags)
+
+    def test_to_string(self, condition_factory: ConditionFactory) -> None:
+        """``ToString`` renders the condition as text."""
+        assert isinstance(condition_factory.by_name("OK").ToString(), str)

--- a/tests/unit/core/test_event_handlers.py
+++ b/tests/unit/core/test_event_handlers.py
@@ -1,0 +1,204 @@
+"""Unit tests for :mod:`flaui.core.event_handlers` (GH-88).
+
+These cover the pure-Python registration machinery (no running application needed) and the typed
+C# delegate builders, which only require the PythonNet bridge set up by the global conftest.
+"""
+
+import logging
+from typing import Any, Callable, Generator, List
+
+import pytest
+
+from flaui.core.definitions import TreeScope
+from flaui.core.event_handlers import (
+    EventRegistration,
+    _live_registrations,
+    coerce_event_id,
+    coerce_property_id,
+    coerce_tree_scope,
+    make_active_text_position_delegate,
+    make_automation_event_delegate,
+    make_focus_changed_delegate,
+    make_notification_delegate,
+    make_property_changed_delegate,
+    make_structure_changed_delegate,
+    make_text_edit_delegate,
+    safe_invoke,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Generator[None, None, None]:
+    """Ensure the module-level keep-alive registry is empty around each test."""
+    _live_registrations.clear()
+    yield
+    _live_registrations.clear()
+
+
+def _make_registration() -> tuple[EventRegistration, List[Any]]:
+    """Build an :class:`EventRegistration` with a stub handler and a recording unregister callable.
+
+    :return: The registration and the list that records each unregistered handler.
+    """
+    unregistered: List[Any] = []
+    handler = object()
+    registration = EventRegistration(
+        cs_handler=handler,
+        callback=lambda *_: None,
+        unregister=unregistered.append,
+    )
+    return registration, unregistered
+
+
+class TestEventRegistration:
+    """Validate the lifecycle, accessors, and context-manager behaviour."""
+
+    def test_construction_registers_keepalive(self) -> None:
+        """A new registration is tracked in the module-level keep-alive set and is active."""
+        registration, _ = _make_registration()
+
+        assert registration in _live_registrations
+        assert registration.is_active is True
+
+    def test_raw_handler_exposes_cs_handler(self) -> None:
+        """``raw_handler`` returns the C# handler object passed at construction."""
+        handler = object()
+        registration = EventRegistration(handler, lambda *_: None, lambda _: None)
+
+        assert registration.raw_handler is handler
+
+    def test_unregister_invokes_callback_and_drops_keepalive(self) -> None:
+        """``unregister`` calls the unregister callable, deactivates, and leaves the registry."""
+        registration, unregistered = _make_registration()
+
+        registration.unregister()
+
+        assert unregistered == [registration.raw_handler]
+        assert registration.is_active is False
+        assert registration not in _live_registrations
+
+    def test_unregister_is_idempotent(self) -> None:
+        """Calling ``unregister`` twice only unregisters once."""
+        registration, unregistered = _make_registration()
+
+        registration.unregister()
+        registration.unregister()
+
+        assert len(unregistered) == 1
+
+    def test_dispose_is_alias_for_unregister(self) -> None:
+        """``dispose`` mirrors the C# disposable pattern by delegating to ``unregister``."""
+        registration, unregistered = _make_registration()
+
+        registration.dispose()
+
+        assert registration.is_active is False
+        assert len(unregistered) == 1
+
+    def test_context_manager_unregisters_on_exit(self) -> None:
+        """Using the registration as a context manager unregisters on block exit."""
+        registration, unregistered = _make_registration()
+
+        with registration as entered:
+            assert entered is registration
+            assert registration.is_active is True
+
+        assert registration.is_active is False
+        assert unregistered == [registration.raw_handler]
+
+    def test_unregister_drops_keepalive_even_when_callback_raises(self) -> None:
+        """A failing unregister callable still deactivates and drops the keep-alive reference."""
+
+        def _boom(_: Any) -> None:
+            """Stub unregister callable that always fails."""
+            raise RuntimeError("unregister failed")
+
+        registration = EventRegistration(object(), lambda *_: None, _boom)
+
+        with pytest.raises(RuntimeError):
+            registration.unregister()
+
+        assert registration.is_active is False
+        assert registration not in _live_registrations
+
+
+class TestCoercion:
+    """Validate the wrapper-or-raw coercion helpers."""
+
+    def test_coerce_event_id_unwraps_and_passes_through(self) -> None:
+        """A wrapper's ``raw`` is returned; a bare value passes through unchanged."""
+
+        class _Wrapper:
+            raw = "cs-event-id"
+
+        sentinel = object()
+        assert coerce_event_id(_Wrapper()) == "cs-event-id"
+        assert coerce_event_id(sentinel) is sentinel
+
+    def test_coerce_property_id_unwraps_and_passes_through(self) -> None:
+        """A wrapper's ``raw`` is returned; a bare value passes through unchanged."""
+
+        class _Wrapper:
+            raw = "cs-property-id"
+
+        sentinel = object()
+        assert coerce_property_id(_Wrapper()) == "cs-property-id"
+        assert coerce_property_id(sentinel) is sentinel
+
+    def test_coerce_tree_scope_unwraps_enum_and_passes_through(self) -> None:
+        """A ``TreeScope`` enum yields its ``value``; a raw value passes through unchanged."""
+        assert coerce_tree_scope(TreeScope.Subtree) == TreeScope.Subtree.value
+
+        sentinel = object()
+        assert coerce_tree_scope(sentinel) is sentinel
+
+
+class TestSafeInvoke:
+    """Validate that callbacks are invoked and exceptions are logged, never raised."""
+
+    def test_invokes_callback_with_args(self) -> None:
+        """The callback runs with the forwarded positional arguments."""
+        received: List[tuple[Any, ...]] = []
+
+        safe_invoke(lambda *args: received.append(args), 1, "two", 3.0)
+
+        assert received == [(1, "two", 3.0)]
+
+    def test_swallows_and_logs_exception(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An exception in the callback is logged, not propagated, to protect the C# event thread."""
+
+        def _boom() -> None:
+            """Stub callback that always raises."""
+            raise ValueError("callback blew up")
+
+        with caplog.at_level(logging.ERROR, logger="flaui.core.event_handlers"):
+            safe_invoke(_boom)  # must not raise
+
+        assert any("Unhandled exception" in record.message for record in caplog.records)
+
+
+class TestDelegateBuilders:
+    """Validate that each typed delegate builder wraps a Python callable into a C# delegate."""
+
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            make_automation_event_delegate,
+            make_property_changed_delegate,
+            make_structure_changed_delegate,
+            make_notification_delegate,
+            make_focus_changed_delegate,
+            make_active_text_position_delegate,
+            make_text_edit_delegate,
+        ],
+    )
+    def test_builder_returns_delegate(self, builder: Callable[[Callable[..., None]], Any]) -> None:
+        """Each builder returns a non-null C# ``Action`` delegate for the given function."""
+
+        def _noop(*_: Any) -> None:
+            """Placeholder callback handed to the delegate builder."""
+
+        delegate = builder(_noop)
+
+        assert delegate is not None
+        assert "Action" in type(delegate).__name__

--- a/tests/unit/core/test_text_range.py
+++ b/tests/unit/core/test_text_range.py
@@ -1,0 +1,192 @@
+"""Unit tests for :mod:`flaui.core.text_range` (GH-88).
+
+``TextRange`` is a thin 1:1 wrapper over the C# ``ITextRange``; a :class:`unittest.mock.MagicMock`
+stub gives deterministic coverage of every delegating method without a running application. Methods
+that wrap results into :class:`Rectangle` are fed real ``System.Drawing.Rectangle`` values because
+that wrapper validates its input type.
+"""
+
+from unittest.mock import MagicMock
+
+from System.Drawing import Rectangle as CSRectangle  # type: ignore
+import pytest
+
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.definitions import TextPatternRangeEndpoint, TextUnit
+from flaui.core.text_range import TextRange
+from flaui.lib.exceptions import ElementNotFound
+from flaui.lib.system.drawing import Rectangle
+
+
+def _text_range(raw: MagicMock) -> TextRange:
+    """Wrap a stub C# text range in a :class:`TextRange`.
+
+    :param raw: The stub navigator/range mock.
+    :return: A :class:`TextRange` around the stub.
+    """
+    return TextRange(raw_text_range=raw)
+
+
+class TestValidation:
+    """Validate the constructor guard."""
+
+    def test_none_raises_element_not_found(self) -> None:
+        """Constructing with a ``None`` native range raises :class:`ElementNotFound`."""
+        with pytest.raises(ElementNotFound):
+            TextRange(raw_text_range=None)
+
+
+class TestVoidDelegation:
+    """Validate the side-effecting methods forward to the native range."""
+
+    def test_add_to_selection(self) -> None:
+        """``add_to_selection`` calls the native method."""
+        raw = MagicMock()
+        _text_range(raw).add_to_selection()
+        raw.AddToSelection.assert_called_once_with()
+
+    def test_remove_from_selection(self) -> None:
+        """``remove_from_selection`` calls the native method."""
+        raw = MagicMock()
+        _text_range(raw).remove_from_selection()
+        raw.RemoveFromSelection.assert_called_once_with()
+
+    def test_select(self) -> None:
+        """``select`` calls the native method."""
+        raw = MagicMock()
+        _text_range(raw).select()
+        raw.Select.assert_called_once_with()
+
+    def test_scroll_into_view(self) -> None:
+        """``scroll_into_view`` forwards the alignment flag."""
+        raw = MagicMock()
+        _text_range(raw).scroll_into_view(True)
+        raw.ScrollIntoView.assert_called_once_with(True)
+
+    def test_expand_to_enclosing_unit(self) -> None:
+        """``expand_to_enclosing_unit`` forwards the text-unit value."""
+        raw = MagicMock()
+        _text_range(raw).expand_to_enclosing_unit(TextUnit.Word)
+        raw.ExpandToEnclosingUnit.assert_called_once_with(TextUnit.Word.value)
+
+    def test_move_endpoint_by_range(self) -> None:
+        """``move_endpoint_by_range`` forwards endpoint values and the target's native range."""
+        raw = MagicMock()
+        target_raw = MagicMock()
+        target = _text_range(target_raw)
+        _text_range(raw).move_endpoint_by_range(
+            TextPatternRangeEndpoint.Start, target, TextPatternRangeEndpoint.End
+        )
+        raw.MoveEndpointByRange.assert_called_once_with(
+            TextPatternRangeEndpoint.Start.value, target_raw, TextPatternRangeEndpoint.End.value
+        )
+
+
+class TestValueDelegation:
+    """Validate the methods that return scalar values or booleans."""
+
+    def test_compare(self) -> None:
+        """``compare`` forwards the other range and returns the native boolean."""
+        raw = MagicMock()
+        raw.Compare.return_value = True
+        other_raw = MagicMock()
+        assert _text_range(raw).compare(_text_range(other_raw)) is True
+        raw.Compare.assert_called_once_with(other_raw)
+
+    def test_compare_endpoints(self) -> None:
+        """``compare_endpoints`` forwards endpoint values and returns the native int."""
+        raw = MagicMock()
+        raw.CompareEndpoints.return_value = -1
+        other_raw = MagicMock()
+        result = _text_range(raw).compare_endpoints(
+            TextPatternRangeEndpoint.Start, _text_range(other_raw), TextPatternRangeEndpoint.End
+        )
+        assert result == -1
+        raw.CompareEndpoints.assert_called_once_with(
+            TextPatternRangeEndpoint.Start.value, other_raw, TextPatternRangeEndpoint.End.value
+        )
+
+    def test_get_attribute_value(self) -> None:
+        """``get_attribute_value`` forwards the attribute and returns the native value."""
+        raw = MagicMock()
+        raw.GetAttributeValue.return_value = "attr"
+        attribute = object()
+        assert _text_range(raw).get_attribute_value(attribute) == "attr"
+        raw.GetAttributeValue.assert_called_once_with(attribute)
+
+    def test_get_text(self) -> None:
+        """``get_text`` forwards the max length and returns the native text."""
+        raw = MagicMock()
+        raw.GetText.return_value = "hello"
+        assert _text_range(raw).get_text() == "hello"
+        raw.GetText.assert_called_once_with(-1)
+
+    def test_move(self) -> None:
+        """``move`` forwards the unit value/count and returns the native move count."""
+        raw = MagicMock()
+        raw.Move.return_value = 3
+        assert _text_range(raw).move(TextUnit.Character, 3) == 3
+        raw.Move.assert_called_once_with(TextUnit.Character.value, 3)
+
+    def test_move_endpoint_by_unit(self) -> None:
+        """``move_endpoint_by_unit`` forwards endpoint/unit values and the count."""
+        raw = MagicMock()
+        raw.MoveEndpointByUnit.return_value = 2
+        result = _text_range(raw).move_endpoint_by_unit(TextPatternRangeEndpoint.End, TextUnit.Word, 2)
+        assert result == 2
+        raw.MoveEndpointByUnit.assert_called_once_with(
+            TextPatternRangeEndpoint.End.value, TextUnit.Word.value, 2
+        )
+
+
+class TestWrappingDelegation:
+    """Validate the methods that wrap native results into Python types."""
+
+    def test_clone(self) -> None:
+        """``clone`` wraps the native ``Clone()`` result in a new :class:`TextRange`."""
+        raw = MagicMock()
+        clone = _text_range(raw).clone()
+        assert isinstance(clone, TextRange)
+        assert clone.raw_text_range is raw.Clone.return_value
+
+    def test_find_attribute_found_and_missing(self) -> None:
+        """``find_attribute`` wraps a hit and returns ``None`` on a miss."""
+        raw = MagicMock()
+        raw.FindAttribute.return_value = MagicMock()
+        found = _text_range(raw).find_attribute(object(), "v", False)
+        assert isinstance(found, TextRange)
+
+        raw.FindAttribute.return_value = None
+        assert _text_range(raw).find_attribute(object(), "v", True) is None
+
+    def test_find_text_found_and_missing(self) -> None:
+        """``find_text`` wraps a hit and returns ``None`` on a miss."""
+        raw = MagicMock()
+        raw.FindText.return_value = MagicMock()
+        assert isinstance(_text_range(raw).find_text("x", False, True), TextRange)
+
+        raw.FindText.return_value = None
+        assert _text_range(raw).find_text("x", True, False) is None
+
+    def test_get_bounding_rectangles(self) -> None:
+        """``get_bounding_rectangles`` wraps each native rectangle in a :class:`Rectangle`."""
+        raw = MagicMock()
+        raw.GetBoundingRectangles.return_value = [CSRectangle(0, 0, 10, 20), CSRectangle(1, 2, 3, 4)]
+        rectangles = _text_range(raw).get_bounding_rectangles()
+        assert len(rectangles) == 2
+        assert all(isinstance(rect, Rectangle) for rect in rectangles)
+
+    def test_get_children(self) -> None:
+        """``get_children`` wraps each native child in an :class:`AutomationElement`."""
+        raw = MagicMock()
+        raw.GetChildren.return_value = [MagicMock(), MagicMock()]
+        children = _text_range(raw).get_children()
+        assert len(children) == 2
+        assert all(isinstance(child, AutomationElement) for child in children)
+
+    def test_get_enclosing_element(self) -> None:
+        """``get_enclosing_element`` wraps the native element in an :class:`AutomationElement`."""
+        raw = MagicMock()
+        element = _text_range(raw).get_enclosing_element()
+        assert isinstance(element, AutomationElement)
+        assert element.raw_element is raw.GetEnclosingElement.return_value

--- a/tests/unit/core/test_xpath_navigator.py
+++ b/tests/unit/core/test_xpath_navigator.py
@@ -1,0 +1,118 @@
+"""Unit tests for :mod:`flaui.core.xpath_navigator` (GH-88).
+
+Two angles are covered:
+
+* a :class:`unittest.mock.MagicMock` stub navigator gives deterministic coverage of every
+  delegating property/method, and
+* a real navigator rooted at the desktop exercises ``from_element`` and the C# round-trip without
+  launching an application.
+"""
+
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pytest
+
+from flaui.core.automation_elements import AutomationElement
+from flaui.core.xpath_navigator import AutomationElementXPathNavigator
+from flaui.lib.enums import UIAutomationTypes
+from flaui.modules.automation import Automation
+
+
+class TestDelegation:
+    """Validate that each wrapper member forwards to the underlying C# navigator."""
+
+    @pytest.fixture()
+    def raw(self) -> MagicMock:
+        """Return a stub C# navigator with deterministic return values."""
+        stub = MagicMock(name="raw_navigator")
+        stub.Name = "Window"
+        stub.Value = "node-value"
+        stub.NodeType = "Element"
+        stub.MoveToFirstChild.return_value = True
+        stub.MoveToParent.return_value = False
+        stub.MoveToNext.return_value = True
+        stub.MoveToPrevious.return_value = False
+        stub.GetAttribute.return_value = "attr-value"
+        return stub
+
+    @pytest.fixture()
+    def navigator(self, raw: MagicMock) -> AutomationElementXPathNavigator:
+        """Return a navigator wrapping the stub."""
+        return AutomationElementXPathNavigator(raw_navigator=raw)
+
+    def test_name_value_node_type(self, navigator: AutomationElementXPathNavigator) -> None:
+        """The scalar properties forward to the matching C# members."""
+        assert navigator.name == "Window"
+        assert navigator.value == "node-value"
+        assert navigator.node_type == "Element"
+
+    def test_current_element_wraps_underlying_object(
+        self, navigator: AutomationElementXPathNavigator, raw: MagicMock
+    ) -> None:
+        """``current_element`` wraps ``UnderlyingObject`` in an :class:`AutomationElement`."""
+        element = navigator.current_element
+        assert isinstance(element, AutomationElement)
+        assert element.raw_element is raw.UnderlyingObject
+
+    def test_clone_returns_new_wrapper(self, navigator: AutomationElementXPathNavigator, raw: MagicMock) -> None:
+        """``clone`` wraps the C# ``Clone()`` result in a new navigator."""
+        clone = navigator.clone()
+        assert isinstance(clone, AutomationElementXPathNavigator)
+        assert clone.raw_navigator is raw.Clone.return_value
+
+    def test_move_to_root_delegates(self, navigator: AutomationElementXPathNavigator, raw: MagicMock) -> None:
+        """``move_to_root`` calls ``MoveToRoot`` and returns nothing."""
+        assert navigator.move_to_root() is None
+        raw.MoveToRoot.assert_called_once_with()
+
+    def test_move_methods_return_bools(self, navigator: AutomationElementXPathNavigator) -> None:
+        """The ``move_to_*`` navigation methods return the C# boolean result."""
+        assert navigator.move_to_first_child() is True
+        assert navigator.move_to_parent() is False
+        assert navigator.move_to_next() is True
+        assert navigator.move_to_previous() is False
+
+    def test_get_attribute_passes_empty_default(
+        self, navigator: AutomationElementXPathNavigator, raw: MagicMock
+    ) -> None:
+        """``get_attribute`` forwards the name and the C# empty-string default."""
+        assert navigator.get_attribute("AutomationId") == "attr-value"
+        raw.GetAttribute.assert_called_once_with("AutomationId", "")
+
+
+class TestFromElement:
+    """Validate construction from a real element and a live C# round-trip on the desktop tree."""
+
+    @pytest.fixture(scope="class")
+    def desktop(self) -> Generator[AutomationElement, None, None]:
+        """Yield the desktop element from a UIA3 automation, disposing it afterwards."""
+        automation = Automation(UIAutomationTypes.UIA3)
+        try:
+            yield automation.automation_base.get_desktop()
+        finally:
+            automation.cs_automation.Dispose()
+
+    def test_from_element_builds_navigator(self, desktop: AutomationElement) -> None:
+        """``from_element`` roots a navigator at the given element."""
+        navigator = AutomationElementXPathNavigator.from_element(desktop)
+
+        assert isinstance(navigator, AutomationElementXPathNavigator)
+        assert navigator.raw_navigator is not None
+
+    def test_real_navigator_round_trip(self, desktop: AutomationElement) -> None:
+        """A real navigator exposes string node metadata and walks the tree."""
+        navigator = AutomationElementXPathNavigator.from_element(desktop)
+
+        navigator.move_to_root()
+        assert isinstance(navigator.name, str)
+        assert isinstance(navigator.value, str)
+        assert isinstance(navigator.node_type, str)
+
+        # The desktop always has children, so the first move down must succeed.
+        assert navigator.move_to_first_child() is True
+        assert isinstance(navigator.current_element, AutomationElement)
+
+        clone = navigator.clone()
+        assert isinstance(clone, AutomationElementXPathNavigator)
+        assert isinstance(clone.get_attribute("Name"), str)

--- a/tests/unit/lib/test_collections.py
+++ b/tests/unit/lib/test_collections.py
@@ -1,4 +1,6 @@
 """This module contains unit tests to the collections module."""
+from datetime import date
+
 from flaui.lib.collections import TypeCast
 
 class TestTypeCast:
@@ -42,3 +44,22 @@ class TestTypeCast:
 
         for k, v in test_dict.items():
             assert converted[k] == v
+
+    def test_cs_timespan_none(self):
+        """``cs_timespan`` returns ``None`` when given ``None``."""
+        assert TypeCast.cs_timespan(None) is None
+
+    def test_cs_timespan_value(self):
+        """``cs_timespan`` converts milliseconds into a C# ``TimeSpan``."""
+        result = TypeCast.cs_timespan(1500)
+
+        assert result is not None
+        assert result.TotalMilliseconds == 1500
+
+    def test_cs_datetime(self):
+        """``cs_datetime`` parses a Python ``date`` into a C# ``DateTime``."""
+        result = TypeCast.cs_datetime(date(2024, 1, 15))
+
+        assert result.Year == 2024
+        assert result.Month == 1
+        assert result.Day == 15

--- a/tests/unit/lib/test_exceptions.py
+++ b/tests/unit/lib/test_exceptions.py
@@ -1,9 +1,21 @@
 """Unit tests for the FlaUI exception hierarchy and the C# -> Python translation decorator."""
 
 from FlaUI.Core.Exceptions import (  # type: ignore
+    ElementNotAvailableException as CSharpElementNotAvailableException,
+    ElementNotEnabledException as CSharpElementNotEnabledException,
     FlaUIException as CSharpFlaUIException,
+    MethodNotSupportedException as CSharpMethodNotSupportedException,
+    NoClickablePointException as CSharpNoClickablePointException,
+    NotCachedException as CSharpNotCachedException,
+    NotSupportedByFrameworkException as CSharpNotSupportedByFrameworkException,
+    NotSupportedException as CSharpNotSupportedException,
+    PatternNotCachedException as CSharpPatternNotCachedException,
     PatternNotSupportedException as CSharpPatternNotSupportedException,
+    PropertyNotCachedException as CSharpPropertyNotCachedException,
+    PropertyNotSupportedException as CSharpPropertyNotSupportedException,
+    ProxyAssemblyNotLoadedException as CSharpProxyAssemblyNotLoadedException,
 )
+from FlaUI.Core.Identifiers import PatternId, PropertyId  # type: ignore
 import pytest
 import System  # type: ignore
 
@@ -178,3 +190,109 @@ class TestTranslateExceptions:
         with translate_exceptions("ok"):
             value = 1 + 1
         assert value == 2
+
+
+def _property_id() -> PropertyId:
+    """Build a throwaway C# ``PropertyId`` for exceptions that require one.
+
+    :return: A C# ``PropertyId`` instance.
+    """
+    return PropertyId(30005, "TestProp")
+
+
+def _pattern_id() -> PatternId:
+    """Build a throwaway C# ``PatternId``.
+
+    :return: A C# ``PatternId`` instance.
+    """
+    return PatternId(10000, "TestPattern", None)
+
+
+class TestExceptionInstantiation:
+    """Instantiate every Python exception class so default-message ``__init__`` paths run."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ElementNotAvailableException,
+            ElementNotEnabledException,
+            MethodNotSupportedException,
+            NoClickablePointException,
+            NotSupportedByFrameworkException,
+            ProxyAssemblyNotLoadedException,
+            NotCachedException,
+            NotSupportedException,
+            PropertyNotSupportedException,
+            PatternNotSupportedException,
+            PropertyNotCachedException,
+            PatternNotCachedException,
+            ElementNotFound,
+            FlaUIException,
+            SystemException,
+        ],
+    )
+    def test_default_message(self, exc: type) -> None:
+        """Each exception is constructible with no args and carries a non-empty message."""
+        instance = exc()
+        assert str(instance)
+
+
+class TestTranslationLadder:
+    """Exercise every branch of the C# -> Python translation ladder (``_raise_translated``)."""
+
+    @pytest.mark.parametrize(
+        "cs_factory, expected",
+        [
+            (lambda: CSharpPropertyNotSupportedException(_property_id()), PropertyNotSupportedException),
+            (lambda: CSharpPatternNotSupportedException(), PatternNotSupportedException),
+            (lambda: CSharpNotSupportedException(), NotSupportedException),
+            (lambda: CSharpPropertyNotCachedException(), PropertyNotCachedException),
+            (lambda: CSharpPatternNotCachedException(), PatternNotCachedException),
+            (lambda: CSharpNotCachedException(), NotCachedException),
+            (lambda: CSharpNotSupportedByFrameworkException(), NotSupportedByFrameworkException),
+            (lambda: CSharpProxyAssemblyNotLoadedException(), ProxyAssemblyNotLoadedException),
+            (lambda: CSharpNoClickablePointException(), NoClickablePointException),
+            (lambda: CSharpMethodNotSupportedException(), MethodNotSupportedException),
+            (lambda: CSharpElementNotEnabledException(), ElementNotEnabledException),
+            (lambda: CSharpElementNotAvailableException(), ElementNotAvailableException),
+            (lambda: CSharpFlaUIException(), FlaUIException),
+        ],
+    )
+    def test_each_csharp_type_maps_to_python_type(self, cs_factory, expected: type) -> None:
+        """Each specific C# exception maps to its specific Python type, with the original chained."""
+        cs_instance = cs_factory()
+
+        @handle_csharp_exceptions
+        def boom() -> None:
+            """Raise the parametrized C# exception."""
+            raise cs_instance
+
+        with pytest.raises(expected) as info:
+            boom()
+        # Most-derived match: the raised type is exactly ``expected``, not merely a base.
+        assert type(info.value) is expected
+        assert info.value.__cause__ is cs_instance
+
+    def test_property_id_forwarded_from_csharp(self) -> None:
+        """A C# ``PropertyNotSupportedException`` forwards its ``PropertyId`` to the Python exception."""
+
+        @handle_csharp_exceptions
+        def boom() -> None:
+            """Raise a C# PropertyNotSupportedException carrying a PropertyId."""
+            raise CSharpPropertyNotSupportedException(_property_id())
+
+        with pytest.raises(PropertyNotSupportedException) as info:
+            boom()
+        assert info.value.property_id is not None
+
+    def test_pattern_id_forwarded_from_csharp(self) -> None:
+        """A C# ``PatternNotSupportedException`` forwards its ``PatternId`` to the Python exception."""
+
+        @handle_csharp_exceptions
+        def boom() -> None:
+            """Raise a C# PatternNotSupportedException carrying a PatternId."""
+            raise CSharpPatternNotSupportedException(_pattern_id())
+
+        with pytest.raises(PatternNotSupportedException) as info:
+            boom()
+        assert info.value.pattern_id is not None

--- a/tests/unit/lib/test_threading_utils.py
+++ b/tests/unit/lib/test_threading_utils.py
@@ -1,0 +1,83 @@
+"""Unit tests for the STA threading executor utilities."""
+
+import pytest
+
+from flaui.lib.threading_utils import _Result, STAThreadExecutor, get_sta_executor
+
+
+class TestResult:
+    """Validate the ``_Result`` future-like holder directly (on the main thread)."""
+
+    def test_result_returns_value(self) -> None:
+        """``result`` returns the value set by ``set_result``."""
+        result = _Result()
+        result.set_result(99)
+
+        assert result.result() == 99
+
+    def test_result_raises_set_exception(self) -> None:
+        """``result`` re-raises the exception set by ``set_exception``."""
+        result = _Result()
+        result.set_exception(ValueError("boom"))
+
+        with pytest.raises(ValueError, match="boom"):
+            result.result()
+
+
+class TestSTAThreadExecutor:
+    """Validate that callables run on the dedicated STA thread and results/exceptions propagate."""
+
+    def test_run_returns_value(self) -> None:
+        """``run`` returns the callable's value."""
+        executor = STAThreadExecutor()
+
+        assert executor.run(lambda: 21 * 2) == 42
+
+    def test_run_forwards_args_and_kwargs(self) -> None:
+        """Positional and keyword arguments are forwarded to the callable."""
+        executor = STAThreadExecutor()
+
+        def add(a: int, b: int, c: int = 0) -> int:
+            """Sum the three operands."""
+            return a + b + c
+
+        assert executor.run(add, 1, 2, c=3) == 6
+
+    def test_run_propagates_exception(self) -> None:
+        """An exception raised by the callable is re-raised to the caller."""
+        executor = STAThreadExecutor()
+
+        def boom() -> None:
+            """Raise a ValueError."""
+            raise ValueError("kaboom")
+
+        with pytest.raises(ValueError, match="kaboom"):
+            executor.run(boom)
+
+    def test_runs_on_dedicated_sta_thread(self) -> None:
+        """The callable executes on a thread distinct from the caller's."""
+        import threading
+
+        from System.Threading import ApartmentState, Thread  # type: ignore
+
+        executor = STAThreadExecutor()
+        caller_thread_id = threading.get_ident()
+
+        worker_thread_id = executor.run(threading.get_ident)
+        apartment = executor.run(lambda: Thread.CurrentThread.GetApartmentState())
+
+        assert worker_thread_id != caller_thread_id
+        assert apartment == ApartmentState.STA
+
+
+class TestGetSTAExecutor:
+    """Validate the lazily-created singleton executor."""
+
+    def test_returns_same_instance(self) -> None:
+        """Repeated calls return the same shared executor."""
+        assert get_sta_executor() is get_sta_executor()
+
+    def test_singleton_is_executor(self) -> None:
+        """The singleton is a working ``STAThreadExecutor``."""
+        assert isinstance(get_sta_executor(), STAThreadExecutor)
+        assert get_sta_executor().run(lambda: "ok") == "ok"


### PR DESCRIPTION
## Summary

Advances **Phase 0 / #88** (core test coverage toward the 95% v1.0 gate) and wires up **GitHub Pages** publishing for the Zensical docs.

### Coverage (GH-88) — six `flaui.core` modules to ~100%
| Module | Before | After |
|---|---|---|
| `event_handlers.py` | 0% | 100% |
| `xpath_navigator.py` | 0% | 100% |
| `text_range.py` | 77% | 100% |
| `capturing.py` | 71% | 90% (`VideoRecorder.start`/`download_ffmpeg` need ffmpeg/network -> UI suite) |
| `condition_factory.py` | 63% | 100% |
| `automation_base.py` | 62% | 100% |

### Bug fixes (`fix(core)`)
Coverage on `condition_factory.py` surfaced three methods that raised unconditionally; all fixed + regression-tested:
- `PropertyCondition.Not(other)` -> now builds **`self AND NOT other`** (C# `ConditionBase.Not()` is parameterless).
- `PropertyCondition.Equals(value)` -> compared `value.cs_condition.cs_condition` (one level too deep).
- `ConditionFactory.by_localized_control_type(...)` -> passed the enum instead of `.value`.

### Docs -> GitHub Pages
`.github/workflows/docs.yml` now builds the Zensical site (`uv` + `extract_versions.py` + `zensical build --strict -f zensical.toml`) and deploys to Pages via `upload-pages-artifact`/`deploy-pages`. Runs on `ubuntu-latest` (mkdocstrings analyses source statically -- no Windows DLLs needed), mirroring the Azure docs job. Validated locally: strict build passes.

> **Manual step:** set repo **Settings -> Pages -> Source = "GitHub Actions"**. This is mutually exclusive with Azure's dormant branch-based `deploy_docs` (gated off via `PUBLISH_DOCS=false`) -- keep deployment on one system.

## Testing
`uv run --group unit-test pytest tests/unit` -> all green. Ruff + Interrogate (100% docstrings) clean.


### Also folded in (prior GH-88 work, was missing from master)
- `test(unit)`: exceptions, collections, threading_utils coverage
- `test(unit)`: CacheRequest wrapper coverage

Full `tests/unit` now: **288 passed**.
