### PR TITLE
docs: polish landing page, consolidate nav, refresh theme

### DIFF
--- a/docs/agentic-guidelines.md
+++ b/docs/agentic-guidelines.md
@@ -2,6 +2,30 @@
 
 Copy-paste snippets for LLMs (Claude/GPT/Gemini) so generated code follows project rules.
 
+## Use with AI agents and MCP
+
+FlaUI for Python is a clean, typed foundation for **building agent tools** on top of Windows UI
+automation. Because every element, pattern, and input method is exposed as a plain Python call with
+Pydantic-backed types, wrapping `find`, `click`, `type`, and pattern actions as
+[MCP](https://modelcontextprotocol.io/) tools (or any other agent-tool interface) is
+straightforward — an agent can then drive arbitrary Windows applications.
+
+!!! note "An enabling foundation, not a shipped feature"
+
+    This library does **not** ship an MCP server or any built-in agent control. It is the
+    *substrate* you would build one on. A reference MCP server / agent-tool example is tracked as a
+    post-v1 item on the [Roadmap](roadmap.md#wishlist-postv1).
+
+!!! warning "Responsible use"
+
+    Letting an agent click and type into live applications is powerful and risky. If you build
+    agent tooling on this library:
+
+    - Only automate applications and environments you are **authorized** to control.
+    - Prefer scoping tools to a known target window/process rather than the whole desktop.
+    - Add confirmation or dry-run modes for destructive actions, and keep a human in the loop for
+      anything irreversible.
+
 ## System prompt template
 - Call `setup_pythonnet_bridge()` before importing any C# types.
 - Use snake_case for methods/properties; classes stay PascalCase.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,32 @@
 # FlaUI for Python
 
-> The premier Windows UI Automation library for Python.
+> The complete FlaUI Windows UI Automation API — made Pythonic, typed, and batteries-included.
 
 ![FlaUI Logo](logo.png)
 
+<p class="hero-badges" markdown>
+[![PyPI version](https://img.shields.io/pypi/v/flaui-uiautomation-wrapper?color=2dd4bf&label=PyPI)](https://pypi.org/project/flaui-uiautomation-wrapper/)
+[![Python versions](https://img.shields.io/pypi/pyversions/flaui-uiautomation-wrapper?color=2dd4bf)](https://pypi.org/project/flaui-uiautomation-wrapper/)
+[![License](https://img.shields.io/pypi/l/flaui-uiautomation-wrapper?color=2dd4bf)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/blob/master/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/amruthvvkp/flaui-uiautomation-wrapper?style=flat&color=2dd4bf)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper)
+</p>
+
+Automate any Windows application — WinForms, WPF, Win32, or Store apps — from Python with a clean,
+fully typed API that maps **1:1** to the battle-tested [FlaUI](https://github.com/FlaUI/FlaUI) C#
+library. No driver binaries to manage, no framework lock-in.
+
+[Get started](basics.md){ .md-button .md-button--primary }
+[API Reference](api/index.md){ .md-button }
+[Why FlaUI for Python?](motivation.md){ .md-button }
+
 ## Get Started
+
+!!! note "Why the C# examples?"
+
+    Upstream [FlaUI](https://github.com/FlaUI/FlaUI) has limited written documentation, so
+    throughout these docs we pair each Python snippet with the **equivalent C# code** for
+    reference. If you have seen a pattern in the original C# library, the side-by-side tabs make
+    it easy to map it onto the Python API.
 
 === "Python"
 
@@ -33,21 +55,59 @@
     mainWindow.FindFirstByXPath("//Button[@Name='OK']").AsButton().Invoke();
     ```
 
-## Why FlaUI?
+## Why FlaUI for Python?
 
-FlaUI provides a modern, clean, and typed API for automating Windows applications.
+<div class="grid cards" markdown>
 
-- **Native UI Automation**: Built on Microsoft's UI Automation (UIA) technology, allowing you to inspect and interact with any Windows application (WinForms, WPF, Store Apps, etc.).
-- **Modern & Typed**: Fully typed with **Pydantic** models, offering excellent IDE support, autocompletion, and compile-time-like checks.
-- **Batteries Included**: Zero-configuration setup. All necessary dependencies are bundled, so you don't need to manage external driver binaries.
-- **Rich Interaction Model**: Beyond simple clicks, FlaUI fully supports complex UIA patterns (Toggle, Select, Expand, Scroll, etc.) for robust application control.
+-   :material-microsoft-windows:{ .lg .middle } __Native UI Automation__
 
-## Key Features
+    ---
 
-- **Dual-Backend Support**: Seamlessly switch between UIA3 (COM-based, recommended for modern apps) and UIA2 (Managed, for legacy apps).
-- **Advanced Element Search**: flexible strategies including Accessibility ID, Name, XPath, or arbitrary condition logic.
-- **Resilient Automation**: Built-in mechanisms for `Retry`, dynamic timeouts, and input waiting ensure your tests aren't flaky.
-- **Drawing & Debugging**: Helpers to highlight elements on screen during test execution.
+    Built on Microsoft's UI Automation (UIA) so you can inspect and drive any Windows
+    application — WinForms, WPF, Win32, and Store apps alike.
+
+-   :material-shield-check:{ .lg .middle } __Modern & Typed__
+
+    ---
+
+    Every element, pattern, and coordinate is backed by **Pydantic** — giving you
+    autocompletion, IDE intellisense, and validation before calls cross the interop boundary.
+
+-   :material-battery-charging:{ .lg .middle } __Batteries Included__
+
+    ---
+
+    Zero-configuration setup. All FlaUI DLLs are bundled in the wheel — no driver binaries or
+    external runtimes to manage.
+
+-   :material-swap-horizontal:{ .lg .middle } __Dual-Backend Support__
+
+    ---
+
+    Switch seamlessly between **UIA3** (COM-based, for modern apps) and **UIA2** (managed, for
+    legacy apps) with a single argument.
+
+-   :material-magnify:{ .lg .middle } __Advanced Element Search__
+
+    ---
+
+    Find elements by Accessibility ID, Name, XPath, or arbitrary `ConditionFactory` logic — plus
+    a full set of UIA patterns (Toggle, Select, Expand, Scroll, …).
+
+-   :material-shield-refresh:{ .lg .middle } __Resilient & Debuggable__
+
+    ---
+
+    Built-in `Retry`, dynamic timeouts, and input waiting keep tests stable; on-screen overlays,
+    capture, and video recording make failures easy to diagnose.
+
+</div>
+
+## Works with any test framework
+
+No lock-in to a single runner. Use FlaUI for Python with **pytest**, **unittest**,
+**Robot Framework**, **Behave**, **TestPlan**, or your own harness — see the
+[Examples](examples/pytest.md).
 
 ## Bundled Library Versions
 
@@ -67,3 +127,4 @@ FlaUI provides a modern, clean, and typed API for automating Windows application
 - **[Advanced Concepts](advanced.md)**: Master XPath, ConditionFactory, and Caching.
 - **[API Reference](api/index.md)**: Explore the full method documentation for every control.
 - **[Troubleshooting](troubleshooting.md)**: Resolve common setup and finding issues.
+- **[Road to v1.0](release-plan.md)**: See how the project gets to a stable `v1.0.0`, how to test betas, and how docs are versioned.

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -12,6 +12,37 @@ This library was created to:
 - Support plug-and-play usage by packaging all required C# binaries
 - Make it easy to port and run C# UI and unit tests in Python
 
+## How it compares to other Python tools
+
+Several libraries can automate Windows UIs from Python. They differ in the technology they sit on,
+how typed and Pythonic the API feels, and how much of the underlying UI Automation surface they
+expose.
+
+| Tool | Underlying tech | Backends | Typed API / IDE support | Test-framework lock-in | Notes |
+|------|-----------------|----------|-------------------------|------------------------|-------|
+| **FlaUI for Python** (this project) | [FlaUI](https://github.com/FlaUI/FlaUI) C# via [Python.NET](https://github.com/pythonnet/pythonnet) | UIA2 + UIA3 | ✅ Pydantic models, full hints | None — pytest, unittest, Robot, Behave, anything | 1:1 mapping of the FlaUI C# API; bundles all DLLs |
+| [pywinauto](https://github.com/pywinauto/pywinauto) | Pure Python (ctypes/comtypes) | Win32 + UIA | ⚠️ Partial; dynamic attribute access | None | Mature and popular; dynamic API is flexible but harder to introspect |
+| [uiautomation](https://github.com/yinkaisheng/Python-UIAutomation-for-Windows) | `comtypes` over UIA COM | UIA only | ⚠️ Limited | None | Lightweight, single-author; thin wrapper over raw UIA |
+| [robotframework-flaui](https://github.com/GDATASoftwareAG/robotframework-flaui) (RobotFlaUI) | FlaUI C# via Python.NET | UIA2 + UIA3 | ❌ Keyword-based | Robot Framework only | Same engine, but usage limited to Robot keywords and XPath |
+| [WinAppDriver](https://github.com/microsoft/WinAppDriver) + [Appium-Python-Client](https://github.com/appium/python-client) | WebDriver/Appium server | UIA | ⚠️ Selenium-style | None | Server-based; WinAppDriver is no longer actively maintained by Microsoft |
+| [PyAutoGUI](https://github.com/asweigart/pyautogui) / [AutoIt](https://www.autoitscript.com/) | Coordinates + image matching | N/A | ⚠️ | None | Not UIA-aware; brittle for structural automation |
+
+### Where FlaUI for Python fits
+
+- **You want the full FlaUI surface, not a subset.** Unlike RobotFlaUI (Robot Framework + XPath
+  only), this wrapper exposes the complete FlaUI C# API in idiomatic Python.
+- **You value type safety.** Every element, pattern, and coordinate type is backed by Pydantic, so
+  you get autocompletion and validation before calls ever cross the interop boundary.
+- **You are not tied to one test runner.** Use it with pytest, unittest, Robot Framework, Behave,
+  or your own harness — see the [Examples](examples/pytest.md).
+- **You are migrating from C#.** The 1:1 mapping (and side-by-side C# snippets throughout these
+  docs) makes porting existing FlaUI test suites straightforward.
+
+When another tool may be the better fit: choose **pywinauto** if you need pure-Python with no .NET
+runtime and want Win32 (non-UIA) support; choose **uiautomation** for a minimal dependency
+footprint; choose **WinAppDriver/Appium** if you are standardizing on the WebDriver protocol across
+platforms.
+
 ## Advantages over alternatives
 
 - 1:1 mapping of C# endpoints, not just limited to XPath or Robot Framework

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -90,6 +90,7 @@ of truth; this page is the human-friendly summary.
 ## 💡 Wishlist (post‑v1)
 - [ ] [`CustomNavigation` pattern (#121)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/121)
 - [ ] UI recorder / codegen (inspired by FlaUIRecorder & Playwright codegen)
+- [ ] Reference MCP server / agent-tool example exposing element find/click/type as tools (see [Use with AI agents](agentic-guidelines.md#use-with-ai-agents-and-mcp))
 - [ ] Async / `pytest-asyncio` ergonomics evaluation
 - [ ] Enhanced HTML/Allure reporting helpers
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -18,6 +18,19 @@
   height: auto;
 }
 
+/* Home page hero badge row — centered, with comfortable spacing */
+.hero-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem;
+  margin: 0.5rem 0 1.5rem;
+}
+
+.hero-badges img {
+  height: 1.3rem;
+}
+
 /* Grid cards styling for feature boxes */
 .grid.cards {
   display: grid;
@@ -77,13 +90,11 @@ table th {
   border: 1px solid var(--md-default-fg-color--lightest);
 }
 
-/* Navigation tabs enhancement */
+/* Navigation tabs: let the theme palette drive colors (clean white / black).
+   Add a subtle divider so the tab strip reads as part of the header without a
+   heavy colored band. */
 .md-tabs {
-  background: linear-gradient(
-    to bottom,
-    var(--md-primary-fg-color),
-    var(--md-primary-fg-color--dark)
-  );
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
 }
 
 /* Footer: copyright + CTA on the left, social links on the right */

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+<!--
+  Template overrides for the FlaUI for Python docs site.
+  Keep this directory wired up via `custom_dir = "overrides"` in zensical.toml.
+-->
+
+{% block announce %}
+  FlaUI for Python is on the
+  <a href="{{ 'release-plan/' | url }}"><strong>Road to v1.0</strong></a> &mdash;
+  the API is stabilizing. Try the betas and
+  <a href="https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues">share feedback</a>.
+{% endblock %}

--- a/zensical.toml
+++ b/zensical.toml
@@ -17,14 +17,14 @@ extra_javascript = ["https://unpkg.com/mermaid@10.6.1/dist/mermaid.min.js"]
 
 nav = [
   { "Home" = "index.md" },
-  { "Roadmap" = "roadmap.md" },
-  { "Road to v1.0" = "release-plan.md" },
-  { "Upgrade Guide" = "upgrade-guide.md" },
-  { "Motivation" = "motivation.md" },
-  { "Basics" = "basics.md" },
-  { "UIA2 vs UIA3" = "uia2-uia3.md" },
-  { "Advanced" = "advanced.md" },
-  { "Pythonic API" = "pythonic-api.md" },
+  { "Guide" = [
+    { "Basics" = "basics.md" },
+    { "UIA2 vs UIA3" = "uia2-uia3.md" },
+    { "Advanced" = "advanced.md" },
+    { "Pythonic API" = "pythonic-api.md" },
+    { "Concepts" = "concepts.md" },
+    { "Troubleshooting" = "troubleshooting.md" },
+  ] },
   { "API Reference" = [
     { "Overview" = "api/index.md" },
     { "Core" = [
@@ -85,16 +85,6 @@ nav = [
       { "Window" = "api/elements/window.md" },
     ] },
   ] },
-  { "Concepts" = "concepts.md" },
-  { "Troubleshooting" = "troubleshooting.md" },
-  { "Agentic Guidelines" = "agentic-guidelines.md" },
-  { "Contributing" = [
-    { "Guide" = "contributing.md" },
-    { "Development Workflow" = "contributing/development.md" },
-    { "Testing" = "contributing/testing.md" },
-    { "Porting C# Tests" = "contributing/porting-tests.md" },
-    { "Bug Tracking" = "bug-tracking.md" },
-  ] },
   { "Examples" = [
     { "Pytest" = "examples/pytest.md" },
     { "Unittest" = "examples/unittest.md" },
@@ -102,6 +92,20 @@ nav = [
     { "Behave" = "examples/behave.md" },
     { "TestPlan" = "examples/testplan.md" },
     { "Element Cookbook" = "examples/element-cookbook.md" },
+  ] },
+  { "Project" = [
+    { "Motivation" = "motivation.md" },
+    { "Roadmap" = "roadmap.md" },
+    { "Road to v1.0" = "release-plan.md" },
+    { "Upgrade Guide" = "upgrade-guide.md" },
+  ] },
+  { "Contributing" = [
+    { "Guide" = "contributing.md" },
+    { "Development Workflow" = "contributing/development.md" },
+    { "Testing" = "contributing/testing.md" },
+    { "Porting C# Tests" = "contributing/porting-tests.md" },
+    { "Bug Tracking" = "bug-tracking.md" },
+    { "Agentic Guidelines" = "agentic-guidelines.md" },
   ] },
 ]
 
@@ -112,7 +116,10 @@ nav = [
 language = "en"
 logo = "logo.png"
 favicon = "logo.png"
+custom_dir = "overrides"
 features = [
+  "header.autohide",
+  "announce.dismiss",
   "navigation.instant",
   "navigation.tracking",
   "navigation.indexes",
@@ -130,14 +137,14 @@ features = [
 
 [[project.theme.palette]]
 scheme = "default"
-primary = "indigo"
+primary = "white"
 accent = "teal"
 toggle.icon = "lucide/sun"
 toggle.name = "Switch to dark mode"
 
 [[project.theme.palette]]
 scheme = "slate"
-primary = "indigo"
+primary = "black"
 accent = "teal"
 toggle.icon = "lucide/moon"
 toggle.name = "Switch to light mode"
@@ -198,6 +205,15 @@ docstring_style = "sphinx"
 # Markdown extensions
 # ----------------------------------------------------------------------------
 [project.markdown_extensions.admonition]
+
+[project.markdown_extensions.attr_list]
+
+[project.markdown_extensions.md_in_html]
+
+[project.markdown_extensions.def_list]
+
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
 
 [project.markdown_extensions.toc]
 permalink = false


### PR DESCRIPTION
Closes #128

## Summary

Documentation cleanup so the site reads like a polished, mature framework and the navigation is far less cluttered.

## Navigation
- Collapse ~15 top-level tabs into 5: **Home**, **Guide**, **API Reference**, **Examples**, **Project**, **Contributing**.
- New **Guide** group (Basics, UIA2 vs UIA3, Advanced, Pythonic API, Concepts, Troubleshooting) and **Project** group (Motivation, Roadmap, Road to v1.0, Upgrade Guide); **Agentic Guidelines** moves under Contributing.

## Theme
- Replace indigo with a clean **white (light) / black (dark)** Material palette (teal accent).
- Remove the hard-coded `.md-tabs` gradient that painted the nav strip indigo.
- Enable `header.autohide`.
- Add a **dismissible announcement bar** (`announce.dismiss` + `overrides/main.html`) linking to Road to v1.0.

## Landing page
- New hero: tagline, shields badges, CTA buttons.
- Consolidate "Why FlaUI?" + "Key Features" into a feature-card grid (`attr_list` + `md_in_html`).
- Add "Works with any test framework" and "Why the C# examples?" callouts; link Road to v1.0 from Next Steps.

## Content
- Comparison of Python Windows UI automation tools added to `motivation.md`.
- "Use with AI agents and MCP" section added to `agentic-guidelines.md` (framed as an enabling foundation, with a responsible-use note) + post-v1 roadmap wishlist item.
- Enable `def_list` and `pymdownx.tasklist` extensions.

## Verification
- `uv run zensical build --strict -f zensical.toml` passes with no issues.