### PR TITLE
test(ui): normalize Phase 0 bug-backlog markers (GH-76/78/79/80/75/89)

### DIFF
--- a/docs/bug-tracking.md
+++ b/docs/bug-tracking.md
@@ -17,6 +17,10 @@ investigation as a genuine wrapper bug; **Env** = environment guard.
 | [#78](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/78) | Toggle pattern unsupported on WinForms menus | test_menu.py::test_checked_menu_item (2 tests) | UIA2/UIA3 + WinForms | Upstream |
 | [#79](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/79) | Context menu broken with UIA3 + WinForms | test_window.py::test_context_menu (1 test) | UIA3 + WinForms | Upstream |
 | [#80](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/80) | find_all/first_with_options fail on some UIA/platform combos | test_automation_element.py (8 parametrizations) | UIA2 (all), UIA3+WinForms | Wrapper (investigating) |
+
+> **Note on #80 vs #81.** [#81](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/81)
+> is a **closed duplicate** of #80. The in-code markers now reference `GH-80` (the canonical open
+> issue); any lingering `GH-81` references should be treated as `GH-80`.
 | [#82](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/82) | test_get_control_type Tab not found during setup | test_value_converter.py::test_get_control_type | UIA2 + WinForms | Flaky |
 | [#83](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/83) | ListBox select_by_index fails | test_listbox.py::test_select_by_index | UIA3 + WPF | Wrapper (investigating) |
 | [#89](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/89) | Notepad tests on Windows 11 (Store app) | Notepad-based tests (test_getter/search/xpath/keyboard) | Windows 11 | Env (guarded via `skip_notepad_on_win11`) |
@@ -27,6 +31,30 @@ investigation as a genuine wrapper bug; **Env** = environment guard.
 > `bug` marker until a fix is verified against the full UIA2/UIA3 × WinForms/WPF matrix. The #88
 > coverage gate is enforced on the full suite (AppVeyor PR/master) — see
 > [Road to v1.0](release-plan.md).
+
+### Marker taxonomy (which marker to use)
+
+`pytest-bug`'s `@pytest.mark.bug` is **whole-test**: with the default `run=False` it skips the test
+on *every* matrix combo, and with `run=True` it treats the *whole* test as xfail. It cannot express
+"skip on WinForms but pass on WPF". Choose the marker by failure shape:
+
+| Failure shape | Marker | Behaviour | Query |
+|---------------|--------|-----------|-------|
+| Whole test broken/flaky on **all** affected combos, under active triage | `@pytest.mark.bug(id=…, url=…, reason=…, run=True)` | runs, treated as xfail (BUG-PASS / BUG-FAIL); detects a future fix | `-m bug`, `--bug-pattern=GH-XX` |
+| Upstream limitation on **specific** matrix combos only (passes on the rest) | `@pytest.mark.platform_limitation` + a conditional skip fixture (`skip_on_winforms`, `skip_on_uia3_winforms`, …) | healthy combos run for real; only the broken combo is skipped | `-m platform_limitation` |
+| Notepad / Store-app environment guard | `@pytest.mark.skip_notepad_on_win11(reason=…)` | skipped only on Windows 11 (build ≥ 22000) | `-m skip_notepad_on_win11` |
+
+Current assignments after the Phase 0 marker-hygiene pass:
+
+- **#76** (tree, flaky on CI across all combos): `bug(run=True)` — replaced the previous inline
+  `try/except AssertionError → pytest.xfail`.
+- **#78** (menu Toggle, WinForms only) and **#79** (context menu, UIA3+WinForms only):
+  `platform_limitation` + conditional skip fixture — replaced the previous in-body `pytest.skip`.
+- **#75** (combobox, WinForms): `platform_limitation` + `bug` + class-level `xfail`. Restoring real
+  WPF combobox coverage (skip on WinForms only) is deferred to the coverage PR so it can be
+  validated against the full matrix.
+- **#89** (`test_application.py`): aligned to `skip_notepad_on_win11` (was a `windows11` +
+  conditional `xfail`), which also avoids the Win11 Store-notepad launch hanging until timeout.
 
 ## Usage Examples
 

--- a/tests/ui/core/automation_elements/test_automation_element.py
+++ b/tests/ui/core/automation_elements/test_automation_element.py
@@ -224,8 +224,9 @@ class TestAutomationElementAdditional:
         ) == HasLen(1), "There should be one nested element"
 
     @pytest.mark.bug(
-        "GH-81",
-        "find_all_with_options fails on UIA2 (all) and UIA3+WinForms - TreeTraversalOptions support issue",
+        id="GH-80",
+        url="https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/80",
+        reason="find_all_with_options fails on UIA2 (all) and UIA3+WinForms - TreeTraversalOptions support issue",
         run=True,
     )
     def test_find_all_with_options(
@@ -308,8 +309,9 @@ class TestAutomationElementAdditional:
         ) == HasAttributes(control_type=ControlType.Tab), "ControlType should be Tab"
 
     @pytest.mark.bug(
-        "GH-81",
-        "find_first_with_options fails on UIA2+WinForms - TreeTraversalOptions support issue",
+        id="GH-80",
+        url="https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/80",
+        reason="find_first_with_options fails on UIA2+WinForms - TreeTraversalOptions support issue",
         run=True,
     )
     def test_find_first_with_options(

--- a/tests/ui/core/automation_elements/test_combobox.py
+++ b/tests/ui/core/automation_elements/test_combobox.py
@@ -11,6 +11,10 @@ from tests.test_utilities.elements.winforms_application import WinFormsApplicati
 from tests.test_utilities.elements.wpf_application import WPFApplicationElements
 
 
+# GH-75: Combobox is heavily broken on WinForms due to upstream Windows/.NET bugs. The class-level
+# bug marker currently skips the whole class on every matrix combo; restoring WPF coverage (skip on
+# WinForms only) is tracked for the coverage PR, where it can be validated against the full matrix.
+@pytest.mark.platform_limitation
 @pytest.mark.bug(
     id="GH-75",
     url="https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/75",

--- a/tests/ui/core/automation_elements/test_menu.py
+++ b/tests/ui/core/automation_elements/test_menu.py
@@ -130,12 +130,13 @@ class TestMenu:
         assert fancy is not None, "Fancy menu item not found"
         assert fancy.properties.name.value == "Fancy", "Fancy menu item name does not match"
 
-    def test_checked_menu_item(self, menu: Menu, test_application_type: str) -> None:
+    # GH-78: UI Automation does not support the Toggle pattern on menu items in WinForms
+    # applications (upstream limitation). Skipped on WinForms via skip_on_winforms; runs on WPF.
+    # Tagged platform_limitation (queryable via `-m platform_limitation`) rather than `bug`,
+    # because the bug marker is whole-test and would skip the passing WPF combos too.
+    @pytest.mark.platform_limitation
+    def test_checked_menu_item(self, menu: Menu, skip_on_winforms: None) -> None:
         """Tests the checked menu item."""
-        if test_application_type == "WinForms":
-            pytest.skip(
-                "UI Automation currently does not support Toggle pattern on menu items in WinForms applications."
-            )
         edit = menu.get_item_by_name("Edit")
         assert edit is not None, "Edit menu item not found"
         show_label = edit.get_item_by_name("Show Label")

--- a/tests/ui/core/automation_elements/test_tree.py
+++ b/tests/ui/core/automation_elements/test_tree.py
@@ -25,17 +25,22 @@ class TestTree:
         """
         yield test_application.complex_controls_tab.tree_elements
 
+    @pytest.mark.bug(
+        id="GH-76",
+        url="https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/76",
+        reason="Tree selection flaky on AppVeyor CI - the tree intermittently exposes only 1 item "
+        "instead of the expected 2. Passes locally on all combos. run=True so the test still "
+        "executes (BUG-PASS locally, BUG-FAIL on CI) and an eventual fix is detected.",
+        run=True,
+    )
     def test_selection(self, tree_elements: Tree) -> None:
         """Tests Selection of Tree controls"""
         with pytest.raises(ElementNotFound):
             _ = tree_elements.selected_tree_item
 
-        try:
-            assert tree_elements == HasAttributes(items=HasLen(2)), "Tree should have 2 items."
-            tree_elements.items[0].expand()
-            tree_elements.items[0].items[1].expand()
-            tree_elements.items[0].items[1].items[0].select()
-            assert tree_elements.selected_tree_item is not None, "Tree should have a selected item."
-            assert tree_elements.selected_tree_item == HasAttributes(text="Lvl3 a"), "Selected item should be 'Lvl3 a'."
-        except AssertionError:
-            pytest.xfail("Appveyor CI: Tree only has 1 item, known CI issue.")
+        assert tree_elements == HasAttributes(items=HasLen(2)), "Tree should have 2 items."
+        tree_elements.items[0].expand()
+        tree_elements.items[0].items[1].expand()
+        tree_elements.items[0].items[1].items[0].select()
+        assert tree_elements.selected_tree_item is not None, "Tree should have a selected item."
+        assert tree_elements.selected_tree_item == HasAttributes(text="Lvl3 a"), "Selected item should be 'Lvl3 a'."

--- a/tests/ui/core/automation_elements/test_window.py
+++ b/tests/ui/core/automation_elements/test_window.py
@@ -2,29 +2,26 @@
 
 from dirty_equals import HasAttributes, HasLen
 from flaui.core.input import Mouse, MouseButton
-from flaui.lib.enums import UIAutomationTypes
 import pytest
 
 from tests.test_utilities.elements.winforms_application import WinFormsApplicationElements
 from tests.test_utilities.elements.wpf_application import WPFApplicationElements
 
-# UIA3 WinForms test is Broken in newer .NET Versions
-# TODO: Somehow the context menu of Winforms isn't getting captured, fix it and run this test
-
 
 class TestWindow:
     """Tests for Window control."""
 
+    # GH-79: Context menu of WinForms is not captured with UIA3 on newer .NET versions (upstream
+    # limitation). Skipped on UIA3 + WinForms via skip_on_uia3_winforms; runs on the other three
+    # matrix combinations. Tagged platform_limitation (queryable via `-m platform_limitation`)
+    # rather than `bug`, because the bug marker is whole-test and would skip the healthy combos too.
+    @pytest.mark.platform_limitation
     def test_context_menu(
         self,
         test_application: WinFormsApplicationElements | WPFApplicationElements,
-        ui_automation_type: UIAutomationTypes,
-        test_application_type: str,
+        skip_on_uia3_winforms: None,
     ) -> None:
         """Tests Context Menu of Window controls"""
-        if ui_automation_type == UIAutomationTypes.UIA3 and test_application_type == "WinForms":
-            pytest.skip("Context menu of WinForms is not working with UIA3 on newer .NET versions")
-
         button = test_application.simple_controls_tab.context_menu_button
         Mouse.click(button.get_clickable_point(), mouse_button=MouseButton.Right, post_wait=True)
         try:

--- a/tests/ui/test_application.py
+++ b/tests/ui/test_application.py
@@ -7,15 +7,12 @@ import logging
 logger = logging.getLogger(__name__)
 import pytest
 
-from tests.test_utilities.os_platform import is_windows_11
-
 
 @pytest.mark.windows11
-@pytest.mark.xfail(
-    is_windows_11,
-    reason="Notepad has moved to Windows Store framework on Windows 11. "
-    "The Win32 notepad.exe may not launch reliably or have different automation properties. "
-    "Consider using test applications (WinForms/WPF) instead of Notepad for stable testing.",
+@pytest.mark.skip_notepad_on_win11(
+    reason="Notepad has moved to the Windows Store framework on Windows 11; the Win32 notepad.exe "
+    "may not launch reliably. Skipped on Windows 11 (see issue #89); use WinForms/WPF test "
+    "applications for stable coverage."
 )
 def test_application() -> None:
     """Tests the application module.


### PR DESCRIPTION
## Summary

Phase 0 stabilization — **marker hygiene** (PR1 of the Phase 0 series). No production code
changes; this is pure test-classification cleanup so the bug backlog is queryable and the
matrix-conditional cases behave correctly.

### Why

`pytest-bug`'s `@pytest.mark.bug` is **whole-test**: the default `run=False` skips the test on
*every* UIA2/UIA3 × WinForms/WPF combo, and `run=True` treats the *whole* test as xfail. It cannot
express "skip on WinForms but pass on WPF". Several backlog items used ad-hoc in-body
`pytest.skip()` / `pytest.xfail()` instead of markers, so the backlog wasn't queryable and some
cases were classified with the wrong tool. This standardizes the taxonomy by failure shape.

### Changes

| Issue | Before | After |
|-------|--------|-------|
| **GH-76** tree (flaky on CI, all combos) | inline `try/except → pytest.xfail` | `@pytest.mark.bug(run=True)` |
| **GH-78** menu Toggle (WinForms only) | in-body `if WinForms: skip` | `@pytest.mark.platform_limitation` + `skip_on_winforms` fixture |
| **GH-79** context menu (UIA3+WinForms only) | in-body combo `skip` | `@pytest.mark.platform_limitation` + `skip_on_uia3_winforms` fixture |
| **GH-80** find_*_with_options | markers referenced `GH-81` | reconciled to `GH-80`; **#81 is a CLOSED duplicate of #80** |
| **GH-75** combobox | `bug` + `xfail` | added `platform_limitation` tag (see note below) |
| **GH-89** `test_application.py` | `windows11` + conditional `xfail` | `skip_notepad_on_win11` (avoids Win11 Store-notepad launch hang) |

`docs/bug-tracking.md` now documents the **marker taxonomy** (`bug` → `-m bug`;
`platform_limitation` → `-m platform_limitation`; `skip_notepad_on_win11` env guard) and the
#80/#81 reconciliation.

### Notes / follow-ups
- **GH-75 combobox**: the class-level `bug` marker currently skips *all* combos (including WPF), so
  WPF combobox coverage is effectively zero today. Restoring it (skip on WinForms only) is a real
  coverage change that needs full-matrix validation, so it is **deferred to the coverage PR**.

### Verification
- `uv run pytest --co` — full suite collects cleanly (995 tests).
- `uv run pytest --co -m platform_limitation …` selects the menu/window parametrizations.
- `uv run pytest --co -m bug …` selects the tree/automation_element parametrizations.
- `uv run ruff check` — clean on all changed files; pre-commit hooks pass.
