### PR TITLE
chore(v1): GitHub Actions PyPI publishing + v1.0.0 release prep

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,80 @@
+name: Publish to PyPI
+
+# Builds the package at a given tag and uploads it to PyPI using the repository
+# `PYPI_API_TOKEN` secret. This is the single PyPI publish path; it is invoked three ways:
+#
+#   1. workflow_call  — from release-beta.yml after a beta pre-release + tag is cut on merge to
+#                       master (the beta is published via GITHUB_TOKEN, which by design does NOT
+#                       trigger a `release`/tag workflow, so the beta flow calls this explicitly).
+#   2. release:published — when you publish the drafted stable release from GitHub Releases (a
+#                       human action, so it DOES trigger this), shipping the stable v1.0.0 to PyPI.
+#   3. workflow_dispatch — manual backfill: build and publish an existing tag (e.g. v1.0.0b1) that
+#                       was tagged on GitHub but never reached PyPI.
+#
+# The version is taken from the tag (v1.0.0b3 -> 1.0.0b3); PyPI auto-classifies bN as a
+# pre-release, so the same path serves betas and the final release. Uploads use skip-existing so
+# re-runs are idempotent.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing git tag to build and publish (e.g. v1.0.0b1)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to build and publish (e.g. v1.0.0b3)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-pypi-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag and version
+        id: tag
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag || github.event.release.tag_name }}"
+          if [[ -z "$TAG" ]]; then
+            echo "::error::No tag resolved from inputs or release event." >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing version ${VERSION} (tag ${TAG})"
+
+      - name: Checkout at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set version and build
+        run: |
+          set -euo pipefail
+          uv version --frozen "${{ steps.tag.outputs.version }}"
+          uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,52 @@
+name: Publish dev build to TestPyPI
+
+# On every pull request to master, build a unique dev version (1.0.0.dev<run_id>) and upload it to
+# TestPyPI so reviewers can install the candidate:
+#
+#   pip install -i https://test.pypi.org/simple/ flaui-uiautomation-wrapper
+#
+# Each run mints a unique 1.0.0.dev<run_id>, so uploads never collide (skip-existing guards re-runs).
+#
+# NOTE: pull_request only exposes secrets for branches in THIS repository (the maintainer's own
+# branches). PRs from forks have no access to TEST_PYPI_API_TOKEN and the upload step is skipped.
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: testpypi-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  testpypi:
+    name: Build and publish to TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set dev version and build
+        run: |
+          set -euo pipefail
+          VERSION="1.0.0.dev${{ github.run_id }}"
+          uv version --frozen "$VERSION"
+          uv build
+          echo "Built dev version ${VERSION}"
+
+      - name: Publish to TestPyPI
+        # Skipped automatically for fork PRs, where the secret is not available.
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,12 +1,16 @@
 name: Cut beta pre-release
 
 # On merge to master, mint the next 1.0.0bN beta: publish a GitHub pre-release (with notes
-# drafted by release-drafter from the merged PRs) tagged v1.0.0bN. Pushing that tag triggers the
-# Azure Pipelines `deploy_pypi` stage, which builds and uploads the wheel/sdist to PyPI.
+# drafted by release-drafter from the merged PRs) tagged v1.0.0bN, then build and upload that
+# version to PyPI via the reusable publish-pypi.yml workflow.
+#
+# The beta release is published with GITHUB_TOKEN, which by design does NOT trigger a downstream
+# `release`/tag workflow, so we publish to PyPI by calling publish-pypi.yml explicitly (rather than
+# relying on its `release: published` trigger).
 #
 # Safe by default: the job is inert unless the repository variable ENABLE_BETA_RELEASES == 'true'
-# (Settings -> Secrets and variables -> Actions -> Variables). Flip it on once the PyPI token and
-# Azure `PUBLISH_PYPI` flag are configured and you're ready for continuous betas.
+# (Settings -> Secrets and variables -> Actions -> Variables). The PyPI upload uses the repository
+# PYPI_API_TOKEN secret.
 
 on:
   push:
@@ -25,6 +29,8 @@ jobs:
   cut-beta:
     if: vars.ENABLE_BETA_RELEASES == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.ver.outputs.tag }}
     steps:
       - name: Compute next beta version
         id: ver
@@ -62,3 +68,12 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build the freshly-tagged beta and upload it to PyPI. Runs only if cut-beta succeeded
+  # (skipped automatically when ENABLE_BETA_RELEASES is not 'true', since cut-beta is then skipped).
+  publish-pypi:
+    needs: cut-beta
+    uses: ./.github/workflows/publish-pypi.yml
+    with:
+      tag: ${{ needs.cut-beta.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -8,8 +8,9 @@ name: Draft stable release
 #   2. release-drafter creates/updates a DRAFT release with notes compiled from
 #      the PRs merged since the previous release. No git tag is created yet.
 #   3. You review the draft in GitHub Releases and click "Publish release".
-#      Publishing creates the tag v<version>, which triggers the Azure Pipelines
-#      `deploy_pypi` (and `deploy_docs`) stage to ship the wheel/sdist to PyPI.
+#      Publishing creates the tag v<version> and emits a `release: published`
+#      event (a human action, so it triggers workflows), which runs
+#      publish-pypi.yml to build and ship the wheel/sdist to PyPI.
 #
 # Because the tag is only created when you publish the draft, nothing reaches
 # PyPI without an explicit human action, and no workflow pushes to `master`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ order we'll tackle the rest.
 | 3 | [Elements & ScrollBars](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/10) | ✅ Done | 0 / 2 |
 | 4 | [Events](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/11) | ✅ Done | 0 / 2 |
 | 5 | [Capturing / Overlay / Video](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/12) | ✅ Done | 0 / 2 |
-| 6 | [Logging / Tools / Enhancers](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/13) | 🟡 In progress | 1 / 3 |
+| 6 | [Logging / Tools / Enhancers](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/13) | ✅ Done | 1 / 3 |
 | 7 | [Docs & Zensical](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/14) | 🟡 In progress | 5 / 0 |
 | 8 | [Polish & v1.0](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/15) | ⏳ Pending | 5 / 0 |
 
@@ -64,11 +64,14 @@ order we'll tackle the rest.
 - **#95** Screen capture & video (`flaui/core/capturing.py` — `Capture`, `CaptureImage`,
   `VideoRecorder`) · **#103** Overlay system (`flaui/core/overlay.py` — `OverlayManager`).
 
-### Phase 6 — Logging / Tools *(partial)*
+### Phase 6 — Logging / Tools / Enhancers *(complete)*
 - **#96** Logging infrastructure (stdlib `logging`, opt-in C#→Python sink via `FLAUI_LOG_CSHARP`) ·
   **#68** mouse busy-spinner / loading-state wait helper.
 - **#100** Tools/utilities: `ItemRealizer`, `AccessibilityTextResolver`, `WindowsStoreAppLauncher`,
   `LocalizedStrings`, `SystemInfo` (**PR #123**).
+- **#87** Pythonic enhancers: `__repr__`, `Application`/`Automation` context managers,
+  `AutomationElementCollection` (`.first`/`.filter`/`.where` + iteration/indexing), `expect()` fluent
+  assertions (`flaui/core/expectations.py`), `py.typed` marker + `ty` type-check gate in CI.
 
 ### Infrastructure
 - **#107** Python `AutomationBase` + UIA2/UIA3 facades · **#118** CI migrated to Azure Pipelines
@@ -78,8 +81,9 @@ order we'll tackle the rest.
 
 ## ⏳ Pending — prioritized backlog
 
-Phases 1–5 are now complete (exceptions/identifiers, patterns, elements, events, capturing/overlay/
-video). The remaining v1.0 gate is **Phase 0 → 7 → 8**, in that priority order.
+Phases 1–6 are now complete (exceptions/identifiers, patterns, elements, events, capturing/overlay/
+video, logging/tools/Pythonic enhancers). The remaining v1.0 gate is **Phase 0 → 7 → 8**, in that
+priority order.
 
 ### P1 — Phase 0: Stabilize *(pre-release gate — active)*
 - **[#88](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/88)** — `flaui.core` test
@@ -106,11 +110,6 @@ video). The remaining v1.0 gate is **Phase 0 → 7 → 8**, in that priority ord
   **[#84](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/84) v1.0.0 release**.
   *(Tag-driven beta automation is wired — see [Release automation](#release-automation) — pending
   token enablement.)*
-
-### Remaining Phase 6
-- **[#87](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/87)** — Enhanced Python
-  integration (umbrella): context managers, iterators, `__repr__`/`__str__`, fluent waits. *Triage;
-  not all required for v1.0.*
 
 ### Post-v1 — parity gaps & deferred tests (out of scope for v1.0)
 - **[#121](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/121)** — CustomNavigation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,6 +121,7 @@ stages:
           - bash: |
               uv sync --group docs
               uv run python scripts/extract_versions.py
+              uv run python scripts/build_changelog.py
               uv run zensical build --strict -f zensical.toml
             displayName: Build docs
             env:
@@ -467,9 +468,11 @@ stages:
                     # Tokenised origin so mike can push the gh-pages branch.
                     git remote set-url origin "https://x-access-token:${GITHUB_PAGES_TOKEN}@github.com/amruthvvkp/flaui-uiautomation-wrapper.git"
 
-                    # Regenerate the bundled-versions include the docs build depends on.
+                    # Regenerate the bundled-versions include and the live changelog the docs
+                    # build depends on (both are gitignored, generated artifacts).
                     uv sync --group docs
                     uv run python scripts/extract_versions.py
+                    uv run python scripts/build_changelog.py
 
                     # mike (Zensical's fork) builds the docs and commits them to gh-pages, keeping
                     # each version under its own subdir and updating the moving alias. It is installed

--- a/docs/bug-tracking.md
+++ b/docs/bug-tracking.md
@@ -22,7 +22,7 @@ investigation as a genuine wrapper bug; **Env** = environment guard.
 > is a **closed duplicate** of #80. The in-code markers now reference `GH-80` (the canonical open
 > issue); any lingering `GH-81` references should be treated as `GH-80`.
 | [#82](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/82) | test_get_control_type Tab not found during setup | test_value_converter.py::test_get_control_type | UIA2 + WinForms | Flaky |
-| [#83](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/83) | ListBox select_by_index fails | test_listbox.py::test_select_by_index | UIA3 + WPF | Wrapper (investigating) |
+| [#83](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/83) | ListBox select_by_index fails | test_listbox.py::test_select_by_index | UIA3 + WPF | Not reproducible — CI flake (monitor `run=True`) |
 | [#89](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/89) | Notepad tests on Windows 11 (Store app) | Notepad-based tests (test_getter/search/xpath/keyboard) | Windows 11 | Env (guarded via `skip_notepad_on_win11`) |
 
 > **Triage policy (Phase 0).** Upstream issues are documented and skipped with `platform_limitation`

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -65,27 +65,38 @@ the whole point of this stage.
 Releases are **tag-driven**, which sidesteps the protected-`master` problem (no workflow needs to
 push commits to `master`):
 
+PyPI publishing runs entirely on **GitHub Actions** using the repository `PYPI_API_TOKEN` /
+`TEST_PYPI_API_TOKEN` secrets. `publish-pypi.yml` is the single PyPI publish path (it builds the
+package at a tag and uploads it); `publish-testpypi.yml` handles pull-request dev builds.
+
 | Event | What happens | Where |
 |-------|--------------|-------|
-| **Pull request** | A dev build `1.0.0.dev<buildId>` is published to **TestPyPI** so reviewers can install the candidate. | Azure `deploy_testpypi` |
-| **Merge to `master`** | The `release-beta` GitHub Action mints the next `1.0.0bN`, publishes a GitHub **pre-release** with notes drafted by [release-drafter](https://github.com/release-drafter/release-drafter) from the merged PRs, and pushes tag `v1.0.0bN`. | `.github/workflows/release-beta.yml` |
-| **Tag `v1.0.0bN` pushed** | Azure builds the wheel/sdist and uploads to **PyPI**. PyPI auto-classifies it as a pre-release (only `--pre` installs it). | Azure `deploy_pypi` |
-| **Stable release (manual)** | You run the **Draft stable release** workflow (Actions → Run workflow → type the version, e.g. `1.0.0`). It creates a **draft** release with notes compiled from merged PRs — *no tag is pushed yet*. You review the draft and click **Publish**, which creates tag `v1.0.0`. | `.github/workflows/release-stable.yml` |
-| **Tag `v1.0.0` pushed** (by publishing the draft) | Same path publishes the **stable** release to PyPI; docs `stable` alias becomes default. | Azure `deploy_pypi` + `deploy_docs` |
+| **Pull request** | A dev build `1.0.0.dev<run_id>` is published to **TestPyPI** so reviewers can install the candidate. | `.github/workflows/publish-testpypi.yml` |
+| **Merge to `master`** | The `release-beta` workflow mints the next `1.0.0bN`, publishes a GitHub **pre-release** with notes drafted by [release-drafter](https://github.com/release-drafter/release-drafter), pushes tag `v1.0.0bN`, then calls `publish-pypi.yml` to build and upload to **PyPI**. PyPI auto-classifies it as a pre-release (only `--pre` installs it). | `release-beta.yml` → `publish-pypi.yml` |
+| **Stable release (manual)** | You run the **Draft stable release** workflow (Actions → Run workflow → type the version, e.g. `1.0.0`). It creates a **draft** release — *no tag yet*. You review and click **Publish**, which creates tag `v1.0.0` and emits a `release: published` event. | `.github/workflows/release-stable.yml` |
+| **Publishing the stable draft** | The `release: published` event runs `publish-pypi.yml`, which ships the **stable** release to PyPI. | `release-stable.yml` → `publish-pypi.yml` |
+| **Manual backfill** | Run `publish-pypi.yml` directly (Actions → Run workflow → enter an existing tag, e.g. `v1.0.0b1`) to build and publish a tag that was created on GitHub but never reached PyPI. | `.github/workflows/publish-pypi.yml` |
 
 Betas are minted and published automatically on merge; the **stable** release is the one human
-checkpoint — nothing reaches PyPI until you publish the reviewed draft from GitHub Releases (which
-is what creates the `v1.0.0` tag).
+checkpoint — nothing stable reaches PyPI until you publish the reviewed draft from GitHub Releases.
+Uploads use `skip-existing`, so re-runs are idempotent.
 
 Each GitHub release links back to its PyPI version and the docs site (see `.github/release-drafter.yml`).
 
-!!! note "Enabling the automation"
-    Everything is **off by default** so nothing publishes until tokens are configured:
+!!! note "Why the beta flow calls publish explicitly"
+    The beta pre-release is published with `GITHUB_TOKEN`, and GitHub does **not** trigger a
+    downstream `release`/tag workflow from `GITHUB_TOKEN` actions (a recursion guard). So
+    `release-beta.yml` invokes `publish-pypi.yml` via `workflow_call` rather than relying on its
+    `release: published` trigger. The stable flow is published by a human, so its `release:
+    published` event fires normally.
 
-    - Azure: set `PUBLISH_TEST_PYPI` / `PUBLISH_PYPI` to `true` and configure the
-      `TEST_PYPI_API_TOKEN` / `PYPI_API_TOKEN` secret pipeline variables.
-    - GitHub: set the repository variable `ENABLE_BETA_RELEASES` to `true`
+!!! note "Enabling / disabling the automation"
+    - **PyPI / TestPyPI**: gated on the repository `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` secrets
+      (Settings → Secrets and variables → Actions → Secrets) — already configured.
+    - **Betas**: set the repository variable `ENABLE_BETA_RELEASES` to `true`
       (Settings → Secrets and variables → Actions → Variables).
+    - The legacy Azure `deploy_testpypi` / `deploy_pypi` stages remain in `azure-pipelines.yml` but
+      stay inert (`PUBLISH_TEST_PYPI` / `PUBLISH_PYPI` = `false`); GitHub Actions owns publishing.
 
 ## Changelog page
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ of truth; this page is the human-friendly summary.
 | [Phase 3 — Elements & ScrollBars](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/10) | Element wrappers, scrollbars | ✅ Complete |
 | [Phase 4 — Events](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/11) | Event handler system, automation events | ✅ Complete |
 | [Phase 5 — Capturing/Overlay/Video](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/12) | Screenshots, overlays, video recording | ✅ Complete |
-| [Phase 6 — Logging/Tools/Enhancers](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/13) | Logging bridge, tools, Pythonic enhancers | 🚧 In progress |
+| [Phase 6 — Logging/Tools/Enhancers](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/13) | Logging bridge, tools, Pythonic enhancers | ✅ Complete |
 | [Phase 0 — Stabilize](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/7) | Green CI, stable matrix, 100% core coverage | 🚧 In progress |
 | [Phase 7 — Docs & Zensical](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/14) | v1 docs, per-framework guides, API reference | 🗓️ Planned |
 | [Phase 8 — Polish & v1.0](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/milestone/15) | Release plumbing, beta soak, v1.0.0 | 🗓️ Planned |
@@ -50,7 +50,13 @@ of truth; this page is the human-friendly summary.
 ### CI & docs platform
 - [x] [Migrate Windows UI CI from AppVeyor to a hybrid Azure Pipelines + AppVeyor setup (#118)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/118)
 - [x] Zensical documentation site with auto-generated API reference (mkdocstrings)
-- [x] `element.__repr__` for readable debugging (part of Phase 6 enhancers)
+
+### Phase 6 — Enhanced Python integration ([#87](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/87))
+- [x] `__repr__` on elements
+- [x] Context-manager support for `Application` / `Automation` (`with` auto-dispose)
+- [x] Iterator/collection protocol on element results (`AutomationElementCollection` with `.first`, `.filter`, `.where`, indexing/iteration)
+- [x] Fluent waiting + Playwright-style assertions (`expect(el).to_be_visible()`, `flaui/core/expectations.py`)
+- [x] `py.typed` marker + `ty` (Astral) type-check gate in CI
 
 ## 🚧 In progress
 
@@ -63,13 +69,6 @@ of truth; this page is the human-friendly summary.
 - [ ] [`ListBox.select_by_index` on UIA3/WPF (#83)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/83) — fix selection
 - [ ] [Notepad tests on Windows 11 Store app (#89)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/89) — environment guard
 - [ ] Document upstream Windows/.NET limitations — [ComboBox/WinForms (#75)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/75), [Toggle on WinForms menus (#78)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/78), [UIA3 WinForms context menus (#79)](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/79)
-
-### Phase 6 — Enhanced Python integration ([#87](https://github.com/amruthvvkp/flaui-uiautomation-wrapper/issues/87))
-- [x] `__repr__` on elements
-- [x] Context-manager support for `Application` / `Automation` (`with` auto-dispose)
-- [ ] Iterator/collection protocol on element results (`.first`, `.filter`, indexing)
-- [ ] Fluent waiting + Playwright-style assertions (`expect(el).to_be_visible()`)
-- [ ] `py.typed` marker + `ty` (Astral) type-check gate in CI
 
 ## 🗓️ Planned
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "flaui-uiautomation-wrapper"
-version = "0.1.0"
+version = "1.0.0"
 description = "Tool to perform UI Automation on Windows desktop applications using an underlying FlaUI wrapper."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "arrow>=1.3.0",
     "pillow>=10.4.0",
+    "psutil>=6.1.1",
     "pydantic>=2.10.6",
     "pydantic-settings>=2.7.1",
     "pythonnet==3.1.0",
@@ -30,7 +31,7 @@ keywords = [
     "qa",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Operating System :: Microsoft :: Windows",
@@ -46,11 +47,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
     "Typing :: Typed",
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: POSIX :: Linux",
-    "Operating System :: MacOS :: MacOS X",
-    "Topic :: Software Development :: Testing",
-    "Intended Audience :: Developers",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -671,11 +671,12 @@ wheels = [
 
 [[package]]
 name = "flaui-uiautomation-wrapper"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pythonnet" },
@@ -720,6 +721,7 @@ requires-dist = [
     { name = "arrow", specifier = ">=1.3.0" },
     { name = "coverage", marker = "extra == 'coverage'", specifier = ">=7.6.1" },
     { name = "pillow", specifier = ">=10.4.0" },
+    { name = "psutil", specifier = ">=6.1.1" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "pytest-sugar", marker = "extra == 'pytest-sugar'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

Gets the wrapper release-ready for v1.0.0 and moves PyPI publishing onto GitHub Actions using the existing repository secrets. **Does not publish v1.0.0** (per direction — that stays a manual checkpoint).

### Release automation (GitHub Actions)
- **`publish-pypi.yml`** — single PyPI publish path. Builds at a tag and uploads (`skip-existing`). Invoked via `workflow_call` (betas), `release: published` (human-published stable draft), and `workflow_dispatch` with a tag input (manual backfill of an existing tag, e.g. `v1.0.0b1`).
- **`publish-testpypi.yml`** — on every PR to `master`, builds `1.0.0.dev<run_id>` and uploads to **TestPyPI**.
- **`release-beta.yml`** — now calls `publish-pypi.yml` so betas reach PyPI (the `GITHUB_TOKEN`-published release can't trigger a downstream `release` workflow, so it's called explicitly).
- Azure `deploy_*` stages stay inert; GitHub Actions owns publishing.

### Release prep
- **Fix:** add `psutil` to runtime dependencies — it was only in the `unit-test` group but is imported by `flaui/core/tools.py`, so a clean `pip install` broke. Caught by a clean-room wheel install.
- Version `0.1.0 → 1.0.0`; classifiers set to `4 - Beta`, deduped, and incorrect Linux/macOS OS classifiers removed (Windows-only).
- Quality gates verified locally: ruff ✓, `ty` ✓, interrogate 99.3% ✓, strict docs build ✓, full suite 95% coverage ✓.

### Docs / tracking
- `ROADMAP.md` + `docs/roadmap.md`: Phase 6 marked complete (enhancers all ship).
- `docs/bug-tracking.md`: GH-83 reconciled to "not reproducible — CI flake".
- `docs/release-plan.md`: documents the GitHub Actions publish flow.

## After merge
- Backfill the existing beta to PyPI: Actions → **Publish to PyPI** → Run workflow → tag `v1.0.0b1`.
- This PR itself exercises `publish-testpypi.yml`.